### PR TITLE
feat: 마이페이지 회원 정보 조회, 수정

### DIFF
--- a/src/main/java/com/study/modoos/common/response/NormalResponse.java
+++ b/src/main/java/com/study/modoos/common/response/NormalResponse.java
@@ -1,0 +1,22 @@
+package com.study.modoos.common.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NormalResponse {
+    private String status;
+
+    protected NormalResponse(String status) {
+        this.status = status;
+    }
+
+    public static NormalResponse success() {
+        return new NormalResponse("SUCCESS");
+    }
+
+    public static NormalResponse fail() {
+        return new NormalResponse("FAIL");
+    }
+}

--- a/src/main/java/com/study/modoos/member/controller/MemberController.java
+++ b/src/main/java/com/study/modoos/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.study.modoos.member.controller;
+
+import com.study.modoos.common.response.NormalResponse;
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.member.request.MemberInfoRequest;
+import com.study.modoos.member.response.MemberInfoResponse;
+import com.study.modoos.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/myInfo")
+    public ResponseEntity<MemberInfoResponse> getMyMemberInfo(Member member) {
+        MemberInfoResponse response = memberService.getMemberInfo(member);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/myInfo")
+    public ResponseEntity<NormalResponse> updateMyMemberInfo(Member member, MemberInfoRequest memberInfoRequest) {
+        memberService.updateMemberInfo(member, memberInfoRequest);
+        return ResponseEntity.ok(NormalResponse.success());
+    }
+}

--- a/src/main/java/com/study/modoos/member/entity/Member.java
+++ b/src/main/java/com/study/modoos/member/entity/Member.java
@@ -1,11 +1,11 @@
 package com.study.modoos.member.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 
 @Entity
 @Getter
@@ -47,4 +47,11 @@ public class Member {
     @Column(name = "isMember")
     private Boolean isMember;
 
+    public void updateNickname(String Nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateCampus(String campus) {
+        this.campus = Campus.valueOf(campus);
+    }
 }

--- a/src/main/java/com/study/modoos/member/repository/MemberRepository.java
+++ b/src/main/java/com/study/modoos/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.study.modoos.member.repository;
+
+import com.study.modoos.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/study/modoos/member/request/MemberInfoRequest.java
+++ b/src/main/java/com/study/modoos/member/request/MemberInfoRequest.java
@@ -1,0 +1,14 @@
+package com.study.modoos.member.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoRequest {
+    private String nickname;
+
+    private String campus;
+}

--- a/src/main/java/com/study/modoos/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/study/modoos/member/response/MemberInfoResponse.java
@@ -1,0 +1,34 @@
+package com.study.modoos.member.response;
+
+import com.study.modoos.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberInfoResponse {
+
+    private String nickname;
+
+    private String email;
+
+    private String campus;
+
+    private String ranking;
+
+    private Long score;
+
+    public static MemberInfoResponse of(Member member) {
+        return MemberInfoResponse.builder()
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .campus(member.getCampus().toString())
+                .ranking(member.getRanking())
+                .score(member.getScore())
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/member/service/MemberService.java
+++ b/src/main/java/com/study/modoos/member/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.study.modoos.member.service;
+
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.member.repository.MemberRepository;
+import com.study.modoos.member.request.MemberInfoRequest;
+import com.study.modoos.member.response.MemberInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberInfoResponse getMemberInfo(Member currentMember) {
+        return memberRepository.findById(currentMember.getId())
+                .map(MemberInfoResponse::of)
+                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾지 못했습니다."));
+    }
+
+    public void updateMemberInfo(Member currentMember, MemberInfoRequest memberInfoRequest) {
+        Long id = currentMember.getId();
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾지 못했습니다."));
+
+        member.updateNickname(memberInfoRequest.getNickname());
+        member.updateCampus(memberInfoRequest.getCampus());
+    }
+}


### PR DESCRIPTION
## 작업 내용 :technologist:
- Member entity에 닉네임, 캠퍼스 수정 로직 추가
- Member Repository 생성
- 마이페이지 정보 조회 시 사용하는 Response Dto 생성
- 회원 정보 수정 시 사용하는 Request Dto 생성
- MemberService, Controller에 관련 로직 추가
- 일반 응답(NormalResponse) 추가

## 반영 브랜치 :rocket:
member/xloyeon -> main

## To Reviewers :speech_balloon:
- MemberController에서 현재 로그인한 사용자가 아닌 일반 Member를 인자로 가져오게 두었어요. 추후 로그인/회원가입 완료 시 수정할 예정입니다.
- 예외 메시지 관련해서 Exception을 새로 만들어 예외 정보, 해결 방법을 전달하게 하면 좋을 것 같아요. 이 부분도 메인 기능 들어가기 전후에 생성하면 좋을 듯 합니다.
