### PR TITLE
refactor: enum 수정 및 모집 공고 기능 제한 추가

### DIFF
--- a/src/main/java/com/study/modoos/auth/controller/AuthController.java
+++ b/src/main/java/com/study/modoos/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.study.modoos.auth.controller;
 
-import com.study.modoos.auth.request.LoginRequest;
-import com.study.modoos.auth.reponse.LoginResponse;
 import com.study.modoos.auth.dto.TokenDto;
+import com.study.modoos.auth.reponse.LoginResponse;
+import com.study.modoos.auth.request.LoginRequest;
 import com.study.modoos.auth.service.AuthService;
 import com.study.modoos.auth.service.EmailService;
+import com.study.modoos.common.response.NormalResponse;
+import com.study.modoos.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final MemberService memberService;
     private final long COOKIE_EXPIRATION = 7776000; // 90일
     private final EmailService emailService;
 
@@ -38,6 +41,7 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build(); // 재발급 필요
         }
     }
+
     // 토큰 재발급
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken,
@@ -87,8 +91,20 @@ public class AuthController {
     }
 
     @PostMapping("/email-confirm")
-    public String emailConfirm(@RequestParam String email) throws Exception{
+    public String emailConfirm(@RequestParam String email) throws Exception {
         return emailService.sendSimpleMessage(email);
     }
 
+    @PostMapping("/email-check")
+    public ResponseEntity<NormalResponse> emailCheck(@RequestParam String email) {
+        if (memberService.emailCheck(email))
+            return ResponseEntity.ok(NormalResponse.fail());
+        return ResponseEntity.ok(NormalResponse.success());
+    }
+
+    @PostMapping("/changePw")
+    public ResponseEntity<NormalResponse> changePassword(@RequestBody @Valid LoginRequest request) {
+        authService.changePassword(request.getEmail(), request.getPassword());
+        return ResponseEntity.ok(NormalResponse.success());
+    }
 }

--- a/src/main/java/com/study/modoos/auth/request/LoginRequest.java
+++ b/src/main/java/com/study/modoos/auth/request/LoginRequest.java
@@ -1,7 +1,11 @@
 package com.study.modoos.auth.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class LoginRequest {
     private String email;

--- a/src/main/java/com/study/modoos/auth/service/AuthService.java
+++ b/src/main/java/com/study/modoos/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.study.modoos.common.exception.ErrorCode;
 import com.study.modoos.common.exception.ModoosException;
 import com.study.modoos.member.entity.Member;
 import com.study.modoos.member.repository.MemberRepository;
+import com.study.modoos.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 public class AuthService {
     private static final String TOKEN_TYPE = "Bearer";
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
     private final RedisService redisService;
@@ -140,6 +142,13 @@ public class AuthService {
         redisService.setValuesWithTimeout(requestAccessToken,
                 "logout",
                 expiration);
+    }
+
+    public void changePassword(String email, String password) {
+        if (!memberService.emailCheck(email))
+            throw new ModoosException(ErrorCode.MEMBER_NOT_FOUND);
+        Member member = memberService.findByEmail(email);
+        member.updatePassword(passwordEncoder.encode((password)));
     }
 }
 

--- a/src/main/java/com/study/modoos/comment/entity/Comment.java
+++ b/src/main/java/com/study/modoos/comment/entity/Comment.java
@@ -4,10 +4,7 @@ import com.study.modoos.common.entity.BaseTimeEntity;
 import com.study.modoos.member.entity.Member;
 import com.study.modoos.study.entity.Study;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -49,7 +46,17 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();
 
-    public void update(Comment comment, String content) {
+    @Builder
+    public Comment(Study study, Member writer, String content, Boolean isDeleted,
+                   Comment parent) {
+        this.study = study;
+        this.writer = writer;
+        this.content = content;
+        this.isDeleted = isDeleted;
+        this.parent = parent;
+    }
+
+    public void updateContent(String content) {
         this.content = content;
     }
 

--- a/src/main/java/com/study/modoos/common/config/SecurityConfig.java
+++ b/src/main/java/com/study/modoos/common/config/SecurityConfig.java
@@ -22,10 +22,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+    private static final String API_PREFIX = "/api";
     private final JwtProvider jwtTokenProvider;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private static final String API_PREFIX = "/api";
 
     public SecurityConfig(JwtProvider jwtTokenProvider, JwtAccessDeniedHandler jwtAccessDeniedHandler, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
         this.jwtTokenProvider = jwtTokenProvider;
@@ -45,22 +45,25 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .exceptionHandling((exceptionHandling) ->
-                        exceptionHandling
-                                .authenticationEntryPoint(jwtAuthenticationEntryPoint) //401 에러 핸들링
-                                .accessDeniedHandler(jwtAccessDeniedHandler)  //403 에러 핸들링
+                                exceptionHandling
+                                        .authenticationEntryPoint(jwtAuthenticationEntryPoint) //401 에러 핸들링
+                                        .accessDeniedHandler(jwtAccessDeniedHandler)  //403 에러 핸들링
 //                                .accessDeniedPage("/errors/access-denied") // 접근 제한 페이지
                 )
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests.requestMatchers(
-                                API_PREFIX + "/member/join",
-                                API_PREFIX + "/member/nickname-check",
+                                        API_PREFIX + "/member/join",
+                                        API_PREFIX + "/member/nickname-check",
                                         API_PREFIX + "/auth/login",
-                                        API_PREFIX + "/auth/email-confirm")
+                                        API_PREFIX + "/auth/email-confirm",
+                                        API_PREFIX + "/auth/email-check",
+                                        API_PREFIX + "/auth/changePw")
                                 .permitAll())
-                .authorizeHttpRequests((authorizeRequests)-> authorizeRequests.anyRequest().authenticated())
+                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests.anyRequest().authenticated())
                 .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -72,7 +75,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtFilter jwtFilter(){
+    public JwtFilter jwtFilter() {
         return new JwtFilter(jwtTokenProvider);
     }
 }

--- a/src/main/java/com/study/modoos/common/exception/ErrorCode.java
+++ b/src/main/java/com/study/modoos/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디를 찾지 못했습니다.", "요청한 스터디가 유효한지 확인해주세요"),
+    STUDY_NOT_EDIT(HttpStatus.NOT_FOUND, "해당 스터디는 이미 생성 완료되었습니다.", "생성 완료된 스터디는 수정, 또는 삭제할 수 없습니다. 스터디가 유효한지 확인해주세요."),
     RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디와 연결된 규칙 정보를 찾지 못했습니다.", "요청한 스터디의 규칙 정보가 유효한지 확인해주세요"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾지 못했습니다.", "email 과 password 를 올바르게 입력했는지 확인해주세요"),
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "email 또는 비밀번호가 맞지 않습니다.", "다른 이메일 또는 비밀번호를 사용해야합니다."),

--- a/src/main/java/com/study/modoos/feedback/entity/Feedback.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Feedback.java
@@ -6,6 +6,7 @@ import com.study.modoos.study.entity.Participant;
 import com.study.modoos.study.entity.Study;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -52,4 +53,18 @@ public class Feedback extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Negative negative;
+
+    @Builder
+    public Feedback(Study study, Participant receiver, Participant sender, int times,
+                    int attend, int deligence, int participate, Positive positive, Negative negative) {
+        this.study = study;
+        this.receiver = receiver;
+        this.sender = sender;
+        this.times = times;
+        this.attend = attend;
+        this.deligence = deligence;
+        this.participate = participate;
+        this.positive = positive;
+        this.negative = negative;
+    }
 }

--- a/src/main/java/com/study/modoos/feedback/entity/Negative.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Negative.java
@@ -1,7 +1,17 @@
 package com.study.modoos.feedback.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,5 +24,15 @@ public enum Negative {
     LACK_OF_RESPONSIBILITY("책임감이 부족해요"),
     LACK_OF_CONSIDERATION("배려심이 아쉬워요");
 
+    private static final Map<String, Negative> negativeMap = Stream.of(values())
+            .collect(Collectors.toMap(Negative::getKeyword, Function.identity()));
+
+    @JsonValue
     private final String keyword;
+
+    @JsonCreator
+    public static Negative resolve(String keyword) {
+        return Optional.ofNullable(negativeMap.get(keyword))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
 }

--- a/src/main/java/com/study/modoos/feedback/entity/Positive.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Positive.java
@@ -1,7 +1,17 @@
 package com.study.modoos.feedback.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,5 +23,15 @@ public enum Positive {
     COMMUNICATION("소통이 잘 돼요"),
     HELP("잘 도와줘요");
 
+    private static final Map<String, Positive> positiveMap = Stream.of(values())
+            .collect(Collectors.toMap(Positive::getKeyword, Function.identity()));
+
+    @JsonValue
     private final String keyword;
+
+    @JsonCreator
+    public static Positive resolve(String keyword) {
+        return Optional.ofNullable(positiveMap.get(keyword))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
 }

--- a/src/main/java/com/study/modoos/member/controller/MemberController.java
+++ b/src/main/java/com/study/modoos/member/controller/MemberController.java
@@ -4,21 +4,16 @@ package com.study.modoos.member.controller;
 import com.study.modoos.common.CurrentUser;
 import com.study.modoos.common.response.NormalResponse;
 import com.study.modoos.member.entity.Member;
-import com.study.modoos.member.request.MemberInfoRequest;
-import com.study.modoos.member.response.MemberInfoResponse;
-import com.study.modoos.member.service.MemberService;
+import com.study.modoos.member.request.ChangeMemberInfoRequest;
 import com.study.modoos.member.request.MemberJoinRequest;
 import com.study.modoos.member.request.MemberNicknameCheckRequest;
+import com.study.modoos.member.response.MemberInfoResponse;
+import com.study.modoos.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,20 +30,23 @@ public class MemberController {
     }
 
     @PutMapping("/myInfo")
-    public ResponseEntity<NormalResponse> updateMyMemberInfo(@CurrentUser Member member, @RequestBody @Valid MemberInfoRequest memberInfoRequest) {
+    public ResponseEntity<NormalResponse> updateMyMemberInfo(@CurrentUser Member member, @RequestBody @Valid ChangeMemberInfoRequest memberInfoRequest) {
         memberService.updateMemberInfo(member, memberInfoRequest);
         return ResponseEntity.ok(NormalResponse.success());
     }
 
 
     @PostMapping("/join")
-    public ResponseEntity<NormalResponse> join(@RequestBody @Valid MemberJoinRequest memberJoinRequest){
+    public ResponseEntity<NormalResponse> join(@RequestBody @Valid MemberJoinRequest memberJoinRequest) {
         memberService.join(memberJoinRequest.joinMember(passwordEncoder));
         return ResponseEntity.ok(NormalResponse.success());
     }
 
     @PostMapping("/nickname-check")
-    public boolean nicknameCheck(@RequestBody @Valid MemberNicknameCheckRequest memberNicknameCheckRequest){
-        return memberService.nicknameCheck(memberNicknameCheckRequest.getNickname());
+    public ResponseEntity<NormalResponse> nicknameCheck(@RequestBody @Valid MemberNicknameCheckRequest memberNicknameCheckRequest) {
+        if (memberService.nicknameCheck(memberNicknameCheckRequest.getNickname())) {
+            return ResponseEntity.ok(NormalResponse.fail());
+        }
+        return ResponseEntity.ok(NormalResponse.success());
     }
 }

--- a/src/main/java/com/study/modoos/member/entity/Campus.java
+++ b/src/main/java/com/study/modoos/member/entity/Campus.java
@@ -1,14 +1,107 @@
 package com.study.modoos.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
 public enum Campus {
-    SEOUL("인문"),
-    YONGIN("자연"),
-    COMMON("공통");
+    SEOUL("인문",
+            Arrays.asList(
+                    Department.MANAGE_INFORMATION,
+                    Department.BUSINESS,
+                    Department.ECONOMICS,
+                    Department.KOREAN,
+                    Department.INTERNATIONAL_TRADE,
+                    Department.GLOBAL_BUSINESS,
+                    Department.GLOBAL_ASSIAN,
+                    Department.GLOBAL_KOREAN,
+                    Department.DIGITAL_MEDIA,
+                    Department.DIGITAL_CONTENT,
+                    Department.WRITING,
+                    Department.LIBRARY_INFORMATION,
+                    Department.ART_HISTORY,
+                    Department.LEGAL_HISTORY,
+                    Department.LAW,
+                    Department.REAL_ESTATE,
+                    Department.HISTORY,
+                    Department.CHILD,
+                    Department.ARABIC,
+                    Department.ENGLISH,
+                    Department.CONVERGENCE_SOFTWARE,
+                    Department.CONVERGENCE_STUDY,
+                    Department.JAPANESE,
+                    Department.INTERDISCIPLINARY_SEOUL,
+                    Department.POLITIC,
+                    Department.CHINESE,
+                    Department.PHILOSOPHY,
+                    Department.YOUTH,
+                    Department.ADMINISTRATION)),
+    YONGIN("자연",
+            Arrays.asList(
+                    Department.ARCHITECTURE,
+                    Department.TRANSPORTATION,
+                    Department.MECHANICAL,
+                    Department.DESIGN,
+                    Department.PHYSICS,
+                    Department.BADUK,
+                    Department.SEMICONDUCTOR,
+                    Department.INDUSTRIAL_MANAGEMENT,
+                    Department.BIOINFORMATICS,
+                    Department.MATH,
+                    Department.SPORTS,
+                    Department.FOOD,
+                    Department.MATERIALS,
+                    Department.ART,
+                    Department.INTERDISCIPLINARY_YONGIN,
+                    Department.ELECTRICAL,
+                    Department.ELECTRONICS,
+                    Department.COMPUTER,
+                    Department.CIVIL_ENVIRONMENTAL,
+                    Department.CHEMICAL,
+                    Department.CHEMISTRY,
+                    Department.ENVIRONMENTAL_ENERGY,
+                    Department.INFORMATION_COMMUNICATION
+            )),
+    COMMON("공통", Collections.EMPTY_LIST);
+
+    private static final Map<String, Campus> campusMap = Stream.of(values())
+            .collect(Collectors.toMap(Campus::getCampusName, Function.identity()));
+
+    @JsonValue
     private final String campusName;
 
+    private List<Department> departmentList;
+
+    Campus(String campusName, List<Department> departmentList) {
+        this.campusName = campusName;
+        this.departmentList = departmentList;
+    }
+
+    @JsonCreator
+    public static Campus resolve(String campusName) {
+        return Optional.ofNullable(campusMap.get(campusName))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
+
+    public static Campus findByDepartment(Department department) {
+        return Arrays.stream(Campus.values())
+                .filter(d -> d.hasDepartment(department))
+                .findAny()
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
+
+    public boolean hasDepartment(Department department) {
+        return departmentList.stream()
+                .anyMatch(d -> d == department);
+    }
 }

--- a/src/main/java/com/study/modoos/member/entity/Department.java
+++ b/src/main/java/com/study/modoos/member/entity/Department.java
@@ -1,0 +1,84 @@
+package com.study.modoos.member.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum Department {
+    MANAGE_INFORMATION("경영정보학과"),
+    BUSINESS("경영학과"),
+    ECONOMICS("경제학과"),
+    KOREAN("국어국문학과"),
+    INTERNATIONAL_TRADE("국제통상학과"),
+    GLOBAL_BUSINESS("글로벌비즈니스전공"),
+    GLOBAL_ASSIAN("글로벌아시아문화학과"),
+    GLOBAL_KOREAN("글로벌한국어학과"),
+    DIGITAL_MEDIA("디지털미디어학과"),
+    DIGITAL_CONTENT("디지털콘텐츠디자인학과"),
+    WRITING("문예창작학과"),
+    LIBRARY_INFORMATION("문헌정보학과"),
+    ART_HISTORY("미술사학과"),
+    LEGAL_HISTORY("법무정책학과"),
+    LAW("법학과"),
+    REAL_ESTATE("부동산학과"),
+    HISTORY("사학과"),
+    CHILD("아동학과"),
+    ARABIC("아랍지역학과"),
+    ENGLISH("영어영문학과"),
+    CONVERGENCE_SOFTWARE("융합소프트웨어학부"),
+    CONVERGENCE_STUDY("융합전공학부"),
+    JAPANESE("일어일문학과"),
+    INTERDISCIPLINARY_SEOUL("전공자유학부(인문)"),
+    INFORMATION_COMMUNICATION("정보통신공학과"),
+    POLITIC("정치외교학과"),
+    CHINESE("중어중문학과"),
+    PHILOSOPHY("철학과"),
+    YOUTH("청소년지도학과"),
+    ADMINISTRATION("행정학과"),
+    ARCHITECTURE("건축학부"),
+    TRANSPORTATION("교통공학과"),
+    MECHANICAL("기계공학과"),
+    DESIGN("디자인학부"),
+    PHYSICS("물리학과"),
+    BADUK("바둑학과"),
+    SEMICONDUCTOR("반도체공학과"),
+    INDUSTRIAL_MANAGEMENT("산업경영공학과"),
+    BIOINFORMATICS("생명과학정보학과"),
+    MATH("수학과"),
+    SPORTS("스포츠학부"),
+    FOOD("식품영양학과"),
+    MATERIALS("신소재공학과"),
+    ART("예술학부"),
+    INTERDISCIPLINARY_YONGIN("전공자유학부(자연)"),
+    ELECTRICAL("전기공학과"),
+    ELECTRONICS("전자공학과"),
+    COMPUTER("컴퓨터공학과"),
+    CIVIL_ENVIRONMENTAL("토목환경공학과"),
+    CHEMICAL("화학공학과"),
+    CHEMISTRY("화학과"),
+    ENVIRONMENTAL_ENERGY("환경에너지공학과");
+
+    private static final Map<String, Department> departmentMap = Stream.of(values())
+            .collect(Collectors.toMap(Department::getTitle, Function.identity()));
+
+    @JsonValue
+    private final String title;
+
+    @JsonCreator
+    public static Department resolve(String title) {
+        return Optional.ofNullable(departmentMap.get(title))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
+
+}

--- a/src/main/java/com/study/modoos/member/entity/Member.java
+++ b/src/main/java/com/study/modoos/member/entity/Member.java
@@ -37,6 +37,11 @@ public class Member {
     private Campus campus;
 
     @NotNull
+    @Column(name = "department", length = 30)
+    @Enumerated(EnumType.STRING)
+    private Department department;
+
+    @NotNull
     @Column(name = "ranking", length = 10)
     private String ranking;
 
@@ -51,6 +56,20 @@ public class Member {
     private Role role;
 
 
+    @Builder
+    public Member(String nickname, String password, String email,
+                  Campus campus, Department department) {
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.campus = campus;
+        this.ranking = "B";
+        this.score = 200L;
+        this.isMember = true;
+        this.role = Role.MEMBER;
+        this.department = department;
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -58,15 +77,12 @@ public class Member {
     public void updateCampus(Campus campus) {
         this.campus = campus;
     }
-    @Builder
-    public Member(String nickname, String password, String email, Campus campus){
-        this.nickname = nickname;
+
+    public void updateDepartment(Department department) {
+        this.department = department;
+    }
+
+    public void updatePassword(String password) {
         this.password = password;
-        this.email = email;
-        this.campus =campus;
-        this.ranking = "B";
-        this.score = 200L;
-        this.isMember = true;
-        this.role = Role.MEMBER;
     }
 }

--- a/src/main/java/com/study/modoos/member/request/ChangeMemberInfoRequest.java
+++ b/src/main/java/com/study/modoos/member/request/ChangeMemberInfoRequest.java
@@ -1,5 +1,7 @@
 package com.study.modoos.member.request;
 
+import com.study.modoos.member.entity.Campus;
+import com.study.modoos.member.entity.Department;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,8 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberInfoRequest {
+public class ChangeMemberInfoRequest {
     private String nickname;
 
-    private String campus;
+    private Campus campus;
+
+    private Department department;
 }

--- a/src/main/java/com/study/modoos/member/request/MemberJoinRequest.java
+++ b/src/main/java/com/study/modoos/member/request/MemberJoinRequest.java
@@ -1,6 +1,7 @@
 package com.study.modoos.member.request;
 
 import com.study.modoos.member.entity.Campus;
+import com.study.modoos.member.entity.Department;
 import com.study.modoos.member.entity.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -21,14 +22,16 @@ public class MemberJoinRequest {
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
-    private String campus;
+    private Campus campus;
+    private Department department;
 
     public Member joinMember(PasswordEncoder passwordEncoder) {
         return Member.builder()
                 .nickname(nickname)
                 .password(passwordEncoder.encode(password))
                 .email(email)
-                .campus(Campus.valueOf(campus))
+                .campus(campus)
+                .department(department)
                 .build();
     }
 

--- a/src/main/java/com/study/modoos/member/response/MemberInfoResponse.java
+++ b/src/main/java/com/study/modoos/member/response/MemberInfoResponse.java
@@ -1,5 +1,7 @@
 package com.study.modoos.member.response;
 
+import com.study.modoos.member.entity.Campus;
+import com.study.modoos.member.entity.Department;
 import com.study.modoos.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +18,9 @@ public class MemberInfoResponse {
 
     private String email;
 
-    private String campus;
+    private Campus campus;
+
+    private Department department;
 
     private String ranking;
 
@@ -26,7 +30,8 @@ public class MemberInfoResponse {
         return MemberInfoResponse.builder()
                 .nickname(member.getNickname())
                 .email(member.getEmail())
-                .campus(member.getCampus().getCampusName())
+                .campus(member.getCampus())
+                .department(member.getDepartment())
                 .ranking(member.getRanking())
                 .score(member.getScore())
                 .build();

--- a/src/main/java/com/study/modoos/member/service/MemberService.java
+++ b/src/main/java/com/study/modoos/member/service/MemberService.java
@@ -3,9 +3,10 @@ package com.study.modoos.member.service;
 import com.study.modoos.common.exception.ErrorCode;
 import com.study.modoos.common.exception.ModoosException;
 import com.study.modoos.member.entity.Campus;
+import com.study.modoos.member.entity.Department;
 import com.study.modoos.member.entity.Member;
 import com.study.modoos.member.repository.MemberRepository;
-import com.study.modoos.member.request.MemberInfoRequest;
+import com.study.modoos.member.request.ChangeMemberInfoRequest;
 import com.study.modoos.member.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,26 +22,31 @@ public class MemberService {
                 .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    public void updateMemberInfo(Member currentMember, MemberInfoRequest memberInfoRequest) {
-        try {
-            currentMember.updateNickname(memberInfoRequest.getNickname());
-            String campus = memberInfoRequest.getCampus();
-            currentMember.updateCampus(Campus.valueOf(campus));
-            memberRepository.save(currentMember);
-        } catch (IllegalArgumentException e) {
+    public void updateMemberInfo(Member currentMember, ChangeMemberInfoRequest memberInfoRequest) {
+        currentMember.updateNickname(memberInfoRequest.getNickname());
+        Campus campus = memberInfoRequest.getCampus();
+        Department department = memberInfoRequest.getDepartment();
+
+        if (!campus.hasDepartment(department))
             throw new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION);
-        }
+        currentMember.updateCampus(campus);
+        currentMember.updateDepartment(department);
+        memberRepository.save(currentMember);
     }
 
     public void join(Member member) {
         if (nicknameCheck(member.getNickname())) {
-            throw new ModoosException(ErrorCode.FORBIDDEN_ARTICLE);
+            throw new ModoosException(ErrorCode.ALREADY_MEMBER);
         }
         memberRepository.save(member);
     }
 
     public boolean nicknameCheck(String nickname) {
         return memberRepository.findByNickname(nickname).isPresent();
+    }
+
+    public boolean emailCheck(String email) {
+        return memberRepository.findByEmail(email).isPresent();
     }
 
     public Member findByEmail(String email) {

--- a/src/main/java/com/study/modoos/recruit/request/ChangeRecruitRequest.java
+++ b/src/main/java/com/study/modoos/recruit/request/ChangeRecruitRequest.java
@@ -1,5 +1,8 @@
 package com.study.modoos.recruit.request;
 
+import com.study.modoos.member.entity.Campus;
+import com.study.modoos.study.entity.Category;
+import com.study.modoos.study.entity.Channel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,9 +13,9 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChangeRecruitRequest {
-    String campus;
-    String channel;
-    String category;
+    Campus campus;
+    Channel channel;
+    Category category;
     LocalDate expected_start_at;
     LocalDate expected_end_at;
     String contact;

--- a/src/main/java/com/study/modoos/recruit/request/RecruitRequest.java
+++ b/src/main/java/com/study/modoos/recruit/request/RecruitRequest.java
@@ -1,5 +1,10 @@
 package com.study.modoos.recruit.request;
 
+import com.study.modoos.member.entity.Campus;
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.study.entity.Category;
+import com.study.modoos.study.entity.Channel;
+import com.study.modoos.study.entity.Study;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,10 +15,10 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecruitRequest {
-    String campus;
+    Campus campus;
     int recruits_count;
-    String channel;
-    String category;
+    Channel channel;
+    Category category;
     LocalDate recruit_deadline;
     LocalDate expected_start_at;
     LocalDate expected_end_at;
@@ -25,4 +30,25 @@ public class RecruitRequest {
     String rule_content;
     String title;
     String description;
+
+    public Study createRecruit(Member member) {
+        return Study.builder()
+                .campus(campus)
+                .leader(member)
+                .recruits_count(recruits_count)
+                .channel(channel)
+                .category(category)
+                .recruit_deadline(recruit_deadline)
+                .expected_start_at(expected_start_at)
+                .expected_end_at(expected_end_at)
+                .contact(contact)
+                .link(link)
+                .late(late)
+                .absent(absent)
+                .out(out)
+                .rule_content(rule_content)
+                .title(title)
+                .description(description)
+                .build();
+    }
 }

--- a/src/main/java/com/study/modoos/recruit/response/RecruitResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitResponse.java
@@ -1,6 +1,8 @@
 package com.study.modoos.recruit.response;
 
-import com.study.modoos.member.entity.Member;
+import com.study.modoos.member.entity.Campus;
+import com.study.modoos.study.entity.Category;
+import com.study.modoos.study.entity.Channel;
 import com.study.modoos.study.entity.Study;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +18,11 @@ import java.time.LocalDate;
 public class RecruitResponse {
     private Long id;
 
-    private Member leader;
+    private Long leader_id;
+
+    private String leader_nickname;
+
+    private String leader_ranking;
 
     private String title;
 
@@ -24,15 +30,15 @@ public class RecruitResponse {
 
     private int status;
 
-    private String category;
+    private Category category;
 
-    private String campus;
+    private Campus campus;
 
     private int recruits_count;
 
     private int participants_count;
 
-    private String channel;
+    private Channel channel;
 
     private LocalDate recruit_deadline;
 
@@ -42,22 +48,30 @@ public class RecruitResponse {
 
     private String link;
 
+    private String contact;
+
+    private boolean isWritten;
+
     public static RecruitResponse of(Study study, boolean isWritten) {
         return RecruitResponse.builder()
                 .id(study.getId())
-                .leader(study.getLeader())
+                .leader_id(study.getLeader().getId())
+                .leader_nickname(study.getLeader().getNickname())
+                .leader_ranking(study.getLeader().getRanking())
                 .title(study.getTitle())
                 .description(study.getDescription())
                 .status(study.getStatus())
-                .category(study.getCategory().getName())
-                .campus(study.getCampus().getCampusName())
+                .category(study.getCategory())
+                .campus(study.getCampus())
                 .recruits_count(study.getRecruits_count())
                 .participants_count(study.getParticipants_count())
-                .channel(study.getChannel().getName())
+                .channel(study.getChannel())
                 .recruit_deadline(study.getRecruit_deadline())
                 .expected_start_at(study.getExpected_start_at())
                 .expected_end_at(study.getExpected_end_at())
                 .link(study.getLink())
+                .contact(study.getContact())
+                .isWritten(isWritten)
                 .build();
     }
 }

--- a/src/main/java/com/study/modoos/study/entity/Category.java
+++ b/src/main/java/com/study/modoos/study/entity/Category.java
@@ -1,7 +1,17 @@
 package com.study.modoos.study.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,5 +23,16 @@ public enum Category {
     PROGRAMMING("프로그래밍"),
     ETC("기타");
 
-    private final String name;
+    private static final Map<String, Category> categoryMap = Stream.of(values())
+            .collect(Collectors.toMap(Category::getCategoryName, Function.identity()));
+
+    @JsonValue
+    private final String categoryName;
+
+    @JsonCreator
+    public static Category resolve(String name) {
+        return Optional.ofNullable(categoryMap.get(name))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+
+    }
 }

--- a/src/main/java/com/study/modoos/study/entity/Channel.java
+++ b/src/main/java/com/study/modoos/study/entity/Channel.java
@@ -1,7 +1,17 @@
 package com.study.modoos.study.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @RequiredArgsConstructor
@@ -10,5 +20,15 @@ public enum Channel {
     ONLINE("온라인"),
     BOTH("병행");
 
-    private final String name;
+    private static final Map<String, Channel> channelMap = Stream.of(values())
+            .collect(Collectors.toMap(Channel::getChannelName, Function.identity()));
+
+    @JsonValue
+    private final String channelName;
+
+    @JsonCreator
+    public static Channel resolve(String name) {
+        return Optional.ofNullable(channelMap.get(name))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
 }

--- a/src/main/java/com/study/modoos/study/entity/Study.java
+++ b/src/main/java/com/study/modoos/study/entity/Study.java
@@ -43,6 +43,7 @@ public class Study {
     @Column(name = "participants_count")
     private int participants_count;
 
+    //0이면 모집중, 1이면 모집완료, 2면 스터디 생성 완료
     @ColumnDefault("0")
     @Column(name = "status")
     private int status;
@@ -102,8 +103,8 @@ public class Study {
 
     @Builder
     public Study(Member leader, String title, String description, int recruits_count,
-                 LocalDate recruit_deadline, String channel, LocalDate expected_start_at,
-                 LocalDate expected_end_at, String category, String campus, String contact,
+                 LocalDate recruit_deadline, Channel channel, LocalDate expected_start_at,
+                 LocalDate expected_end_at, Category category, Campus campus, String contact,
                  String link, String rule_content, int absent, int late, int out) {
         this.leader = leader;
         this.title = title;
@@ -111,29 +112,30 @@ public class Study {
         this.recruits_count = recruits_count;
         this.participants_count = 1;
         this.recruit_deadline = recruit_deadline;
-        this.channel = Channel.valueOf(channel);
+        this.channel = channel;
         this.expected_start_at = expected_start_at;
         this.expected_end_at = expected_end_at;
-        this.category = Category.valueOf(category);
-        this.campus = Campus.valueOf(campus);
+        this.category = category;
+        this.campus = campus;
         this.contact = contact;
         this.link = link;
         this.rule_content = rule_content;
         this.absent = absent;
         this.late = late;
         this.out = out;
+        this.status = 0;
     }
 
-    public void update(String campus, String channel, String category, LocalDate expected_start_at,
+    public void update(Campus campus, Channel channel, Category category, LocalDate expected_start_at,
                        LocalDate expected_end_at, String contact, String link, String title, String description,
                        int absent, int late, int out, String rule_content) {
         this.title = title;
         this.description = description;
-        this.channel = Channel.valueOf(channel);
+        this.channel = channel;
         this.expected_start_at = expected_start_at;
         this.expected_end_at = expected_end_at;
-        this.category = Category.valueOf(category);
-        this.campus = Campus.valueOf(campus);
+        this.category = category;
+        this.campus = campus;
         this.contact = contact;
         this.link = link;
         this.rule_content = rule_content;


### PR DESCRIPTION
## 작업 내용 :technologist:
- enum 값의 직렬화, 역직렬화 로직을 추가하여 값을 통한 탐색이 가능하도록 수정했습니다.
- 이메일 중복체크와 비밀번호 재설정 로직을 추가했습니다.
- 이미 스터디 생성이 된 모집공고는 수정, 삭제가 불가능하도록 예외처리했습니다.

## 반영 브랜치 :rocket:
recruit/xloyeon -> main

## To Reviewers :speech_balloon:
- 비밀번호 재설정 관련하여 securityConfig에서 해당 uri 권한을 허용시켜주으나, 여전히 401 에러가 납니다...
