### PR TITLE
feat: 모집공고 필터링 조회, 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,64 +1,112 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.1'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.1'
+    id 'io.spring.dependency-management' version '1.1.0'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"    //query dsl
 }
 
 group = 'com.study'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 jar {
-	enabled = false
+    enabled = false
 }
 
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// SpringSecurity
-	implementation 'org.springframework.boot:spring-boot-starter-security:3.0.4'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // SpringSecurity
+    implementation 'org.springframework.boot:spring-boot-starter-security:3.0.4'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	//Redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-
-	//io.jsonwebtoken : jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 
-	// com.sun.xml.bind : jwt
-	implementation 'com.sun.xml.bind:jaxb1-impl:2.2.5.1'
-	implementation 'com.sun.xml.bind:jaxb-core:4.0.2'
-	// javax.xml.bind : jwt
-	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+    //io.jsonwebtoken : jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	//email
-	implementation 'org.springframework.boot:spring-boot-starter-mail:3.0.4'
+
+    // com.sun.xml.bind : jwt
+    implementation 'com.sun.xml.bind:jaxb1-impl:2.2.5.1'
+    implementation 'com.sun.xml.bind:jaxb-core:4.0.2'
+    // javax.xml.bind : jwt
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    //email
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.0.4'
+
+    //QueryDsl
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    //java.lang.NoClassDefFoundError 대응
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
+}
+
+//querydsl 사용 경로
+def querydslDir = "src/main/generated"
+
+//querydsl 사용 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+// build 시 사용할 sourceSet
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+// compileClasspath와 annotationProcessor 상속
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
+//feature/improve-all
+// querydsl 컴파일 시 사용할 옵션.
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/generated/com/study/modoos/comment/entity/QComment.java
+++ b/src/main/generated/com/study/modoos/comment/entity/QComment.java
@@ -1,0 +1,71 @@
+package com.study.modoos.comment.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 1291577742L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final com.study.modoos.common.entity.QBaseTimeEntity _super = new com.study.modoos.common.entity.QBaseTimeEntity(this);
+
+    public final ListPath<Comment, QComment> children = this.<Comment, QComment>createList("children", Comment.class, QComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
+    public final QComment parent;
+
+    public final com.study.modoos.study.entity.QStudy study;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.study.modoos.member.entity.QMember writer;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parent = inits.isInitialized("parent") ? new QComment(forProperty("parent"), inits.get("parent")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.modoos.study.entity.QStudy(forProperty("study"), inits.get("study")) : null;
+        this.writer = inits.isInitialized("writer") ? new com.study.modoos.member.entity.QMember(forProperty("writer")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/common/entity/QBaseTimeEntity.java
+++ b/src/main/generated/com/study/modoos/common/entity/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.study.modoos.common.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = -1646621900L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/feedback/entity/QFeedback.java
+++ b/src/main/generated/com/study/modoos/feedback/entity/QFeedback.java
@@ -1,0 +1,77 @@
+package com.study.modoos.feedback.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFeedback is a Querydsl query type for Feedback
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFeedback extends EntityPathBase<Feedback> {
+
+    private static final long serialVersionUID = -1868734190L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFeedback feedback = new QFeedback("feedback");
+
+    public final com.study.modoos.common.entity.QBaseTimeEntity _super = new com.study.modoos.common.entity.QBaseTimeEntity(this);
+
+    public final NumberPath<Integer> attend = createNumber("attend", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Integer> deligence = createNumber("deligence", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<Negative> negative = createEnum("negative", Negative.class);
+
+    public final NumberPath<Integer> participate = createNumber("participate", Integer.class);
+
+    public final EnumPath<Positive> positive = createEnum("positive", Positive.class);
+
+    public final com.study.modoos.study.entity.QParticipant receiver;
+
+    public final com.study.modoos.study.entity.QParticipant sender;
+
+    public final com.study.modoos.study.entity.QStudy study;
+
+    public final NumberPath<Integer> times = createNumber("times", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QFeedback(String variable) {
+        this(Feedback.class, forVariable(variable), INITS);
+    }
+
+    public QFeedback(Path<? extends Feedback> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFeedback(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFeedback(PathMetadata metadata, PathInits inits) {
+        this(Feedback.class, metadata, inits);
+    }
+
+    public QFeedback(Class<? extends Feedback> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.receiver = inits.isInitialized("receiver") ? new com.study.modoos.study.entity.QParticipant(forProperty("receiver"), inits.get("receiver")) : null;
+        this.sender = inits.isInitialized("sender") ? new com.study.modoos.study.entity.QParticipant(forProperty("sender"), inits.get("sender")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.modoos.study.entity.QStudy(forProperty("study"), inits.get("study")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/member/entity/QMember.java
+++ b/src/main/generated/com/study/modoos/member/entity/QMember.java
@@ -1,0 +1,55 @@
+package com.study.modoos.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -256387972L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final EnumPath<Campus> campus = createEnum("campus", Campus.class);
+
+    public final EnumPath<Department> department = createEnum("department", Department.class);
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isMember = createBoolean("isMember");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath ranking = createString("ranking");
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public final NumberPath<Long> score = createNumber("score", Long.class);
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/recruit/entity/QStandby.java
+++ b/src/main/generated/com/study/modoos/recruit/entity/QStandby.java
@@ -1,0 +1,54 @@
+package com.study.modoos.recruit.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QStandby is a Querydsl query type for Standby
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStandby extends EntityPathBase<Standby> {
+
+    private static final long serialVersionUID = -1259742435L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QStandby standby = new QStandby("standby");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.modoos.member.entity.QMember member;
+
+    public final com.study.modoos.study.entity.QStudy study;
+
+    public QStandby(String variable) {
+        this(Standby.class, forVariable(variable), INITS);
+    }
+
+    public QStandby(Path<? extends Standby> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QStandby(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QStandby(PathMetadata metadata, PathInits inits) {
+        this(Standby.class, metadata, inits);
+    }
+
+    public QStandby(Class<? extends Standby> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.study.modoos.member.entity.QMember(forProperty("member")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.modoos.study.entity.QStudy(forProperty("study"), inits.get("study")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/study/entity/QHeart.java
+++ b/src/main/generated/com/study/modoos/study/entity/QHeart.java
@@ -1,0 +1,54 @@
+package com.study.modoos.study.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QHeart is a Querydsl query type for Heart
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QHeart extends EntityPathBase<Heart> {
+
+    private static final long serialVersionUID = 1327961803L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QHeart heart = new QHeart("heart");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.modoos.member.entity.QMember member;
+
+    public final QStudy study;
+
+    public QHeart(String variable) {
+        this(Heart.class, forVariable(variable), INITS);
+    }
+
+    public QHeart(Path<? extends Heart> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QHeart(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QHeart(PathMetadata metadata, PathInits inits) {
+        this(Heart.class, metadata, inits);
+    }
+
+    public QHeart(Class<? extends Heart> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.study.modoos.member.entity.QMember(forProperty("member")) : null;
+        this.study = inits.isInitialized("study") ? new QStudy(forProperty("study"), inits.get("study")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/study/entity/QParticipant.java
+++ b/src/main/generated/com/study/modoos/study/entity/QParticipant.java
@@ -1,0 +1,54 @@
+package com.study.modoos.study.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QParticipant is a Querydsl query type for Participant
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QParticipant extends EntityPathBase<Participant> {
+
+    private static final long serialVersionUID = -1192993288L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QParticipant participant = new QParticipant("participant");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.modoos.member.entity.QMember member;
+
+    public final QStudy study;
+
+    public QParticipant(String variable) {
+        this(Participant.class, forVariable(variable), INITS);
+    }
+
+    public QParticipant(Path<? extends Participant> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QParticipant(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QParticipant(PathMetadata metadata, PathInits inits) {
+        this(Participant.class, metadata, inits);
+    }
+
+    public QParticipant(Class<? extends Participant> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.study.modoos.member.entity.QMember(forProperty("member")) : null;
+        this.study = inits.isInitialized("study") ? new QStudy(forProperty("study"), inits.get("study")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/study/modoos/study/entity/QStudy.java
+++ b/src/main/generated/com/study/modoos/study/entity/QStudy.java
@@ -1,0 +1,101 @@
+package com.study.modoos.study.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QStudy is a Querydsl query type for Study
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStudy extends EntityPathBase<Study> {
+
+    private static final long serialVersionUID = 1338586190L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QStudy study = new QStudy("study");
+
+    public final com.study.modoos.common.entity.QBaseTimeEntity _super = new com.study.modoos.common.entity.QBaseTimeEntity(this);
+
+    public final NumberPath<Integer> absent = createNumber("absent", Integer.class);
+
+    public final EnumPath<com.study.modoos.member.entity.Campus> campus = createEnum("campus", com.study.modoos.member.entity.Campus.class);
+
+    public final EnumPath<Category> category = createEnum("category", Category.class);
+
+    public final EnumPath<Channel> channel = createEnum("channel", Channel.class);
+
+    public final StringPath contact = createString("contact");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final DatePath<java.time.LocalDate> end_at = createDate("end_at", java.time.LocalDate.class);
+
+    public final DatePath<java.time.LocalDate> expected_end_at = createDate("expected_end_at", java.time.LocalDate.class);
+
+    public final DatePath<java.time.LocalDate> expected_start_at = createDate("expected_start_at", java.time.LocalDate.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> late = createNumber("late", Integer.class);
+
+    public final com.study.modoos.member.entity.QMember leader;
+
+    public final StringPath link = createString("link");
+
+    public final NumberPath<Integer> out = createNumber("out", Integer.class);
+
+    public final NumberPath<Integer> participants_count = createNumber("participants_count", Integer.class);
+
+    public final NumberPath<Integer> period = createNumber("period", Integer.class);
+
+    public final DatePath<java.time.LocalDate> recruit_deadline = createDate("recruit_deadline", java.time.LocalDate.class);
+
+    public final NumberPath<Integer> recruits_count = createNumber("recruits_count", Integer.class);
+
+    public final StringPath rule_content = createString("rule_content");
+
+    public final DatePath<java.time.LocalDate> start_at = createDate("start_at", java.time.LocalDate.class);
+
+    public final NumberPath<Integer> status = createNumber("status", Integer.class);
+
+    public final StringPath title = createString("title");
+
+    public final NumberPath<Integer> total_turn = createNumber("total_turn", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QStudy(String variable) {
+        this(Study.class, forVariable(variable), INITS);
+    }
+
+    public QStudy(Path<? extends Study> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QStudy(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QStudy(PathMetadata metadata, PathInits inits) {
+        this(Study.class, metadata, inits);
+    }
+
+    public QStudy(Class<? extends Study> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.leader = inits.isInitialized("leader") ? new com.study.modoos.member.entity.QMember(forProperty("leader")) : null;
+    }
+
+}
+

--- a/src/main/java/com/study/modoos/ModoosApplication.java
+++ b/src/main/java/com/study/modoos/ModoosApplication.java
@@ -2,12 +2,14 @@ package com.study.modoos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ModoosApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ModoosApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ModoosApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/study/modoos/auth/service/AuthService.java
+++ b/src/main/java/com/study/modoos/auth/service/AuthService.java
@@ -145,11 +145,8 @@ public class AuthService {
     }
 
     public void changePassword(String email, String password) {
-        if (!memberService.emailCheck(email))
-            throw new ModoosException(ErrorCode.MEMBER_NOT_FOUND);
-        Member member = memberService.findByEmail(email);
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
         member.updatePassword(passwordEncoder.encode(password));
-        memberRepository.save(member);
     }
 }
 

--- a/src/main/java/com/study/modoos/common/config/QueryDslConfig.java
+++ b/src/main/java/com/study/modoos/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.study.modoos.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
+++ b/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
@@ -5,11 +5,19 @@ import com.study.modoos.common.response.NormalResponse;
 import com.study.modoos.member.entity.Member;
 import com.study.modoos.recruit.request.ChangeRecruitRequest;
 import com.study.modoos.recruit.request.RecruitRequest;
-import com.study.modoos.recruit.response.RecruitResponse;
+import com.study.modoos.recruit.response.RecruitIdResponse;
+import com.study.modoos.recruit.response.RecruitInfoResponse;
 import com.study.modoos.recruit.service.RecruitService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,12 +26,27 @@ public class RecruitController {
     private final RecruitService recruitService;
 
     @PostMapping("/post")
-    public ResponseEntity<RecruitResponse> createRecruit(@CurrentUser Member member, @RequestBody RecruitRequest recruitRequest) {
+    public ResponseEntity<RecruitIdResponse> createRecruit(@CurrentUser Member member, @RequestBody RecruitRequest recruitRequest) {
         return ResponseEntity.ok(recruitService.postRecruit(member, recruitRequest));
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<RecruitInfoResponse> getRecruit(@CurrentUser Member member, @PathVariable(value = "id") Long id) {
+        return ResponseEntity.ok(recruitService.oneRecruit(member, id));
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<Slice<RecruitInfoResponse>> getRecruitList(@CurrentUser Member member,
+                                                                     @RequestParam(value = "category", defaultValue = "") List<String> category,
+                                                                     @RequestParam(value = "searchBy", required = false) String search,
+                                                                     @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, pageable));
+
+    }
+
     @PutMapping("/{id}")
-    public ResponseEntity<RecruitResponse> changeRecruit(@CurrentUser Member member, @PathVariable(value = "id") Long id, @RequestBody ChangeRecruitRequest request) {
+    public ResponseEntity<RecruitIdResponse> changeRecruit(@CurrentUser Member member, @PathVariable(value = "id") Long id, @RequestBody ChangeRecruitRequest request) {
         return ResponseEntity.ok(recruitService.changeRecruit(member, id, request));
     }
 

--- a/src/main/java/com/study/modoos/recruit/response/RecruitIdResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitIdResponse.java
@@ -1,0 +1,21 @@
+package com.study.modoos.recruit.response;
+
+import com.study.modoos.study.entity.Study;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RecruitIdResponse {
+    private Long id;
+
+    public static RecruitIdResponse of(Study study) {
+        return RecruitIdResponse.builder()
+                .id(study.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RecruitResponse {
+public class RecruitInfoResponse {
     private Long id;
 
     private Long leader_id;
@@ -52,8 +52,8 @@ public class RecruitResponse {
 
     private boolean isWritten;
 
-    public static RecruitResponse of(Study study, boolean isWritten) {
-        return RecruitResponse.builder()
+    public static RecruitInfoResponse of(Study study, boolean isWritten) {
+        return RecruitInfoResponse.builder()
                 .id(study.getId())
                 .leader_id(study.getLeader().getId())
                 .leader_nickname(study.getLeader().getNickname())

--- a/src/main/java/com/study/modoos/study/entity/Study.java
+++ b/src/main/java/com/study/modoos/study/entity/Study.java
@@ -1,5 +1,6 @@
 package com.study.modoos.study.entity;
 
+import com.study.modoos.common.entity.BaseTimeEntity;
 import com.study.modoos.member.entity.Campus;
 import com.study.modoos.member.entity.Member;
 import jakarta.persistence.*;
@@ -17,7 +18,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "study")
-public class Study {
+public class Study extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -142,6 +143,10 @@ public class Study {
         this.absent = absent;
         this.late = late;
         this.out = out;
+    }
+
+    public boolean isWrittenPost(Member member) {
+        return this.leader.getId().equals(member.getId());
     }
 
     /*

--- a/src/main/java/com/study/modoos/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/study/modoos/study/repository/StudyRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.study.modoos.study.repository;
+
+import com.study.modoos.recruit.response.RecruitInfoResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRepositoryCustom {
+
+    Slice<RecruitInfoResponse> getRecruitScroll(Pageable pageable);
+}

--- a/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.study.modoos.study.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.recruit.response.RecruitInfoResponse;
+import com.study.modoos.study.entity.Category;
+import com.study.modoos.study.entity.Study;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.study.modoos.study.entity.QStudy.study;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyRepositoryImpl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<RecruitInfoResponse> getSliceOfRecruit(Member member,
+                                                        final String title,
+                                                        final List<Category> categoryList,
+                                                        Pageable pageable) {
+        /*
+        if (order.equals("likeCount")) {
+            content = queryFactory
+                    .selectFrom(study)
+                    .where(allCond(searchCondition))
+                    .orderBy(study.createdAt)
+                    .fetch();
+
+        }
+        */
+        JPAQuery<Study> results = queryFactory.selectFrom(study)
+                .where(
+                        titleLike(title),
+                        categoryEq(categoryList))
+                //.orderBy(study.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1);
+
+        for (Sort.Order o : pageable.getSort()) {
+            PathBuilder pathBuilder = new PathBuilder(study.getType(), study.getMetadata());
+            results.orderBy(new OrderSpecifier(o.isAscending() ? Order.ASC :
+                    Order.DESC, pathBuilder.get(o.getProperty())));
+        }
+
+        List<RecruitInfoResponse> contents = results.fetch()
+                .stream()
+                .map(o -> RecruitInfoResponse.of(o, o.isWrittenPost(member)))
+                .collect(Collectors.toList());
+
+
+        boolean hasNext = false;
+
+
+        if (contents.size() > pageable.getPageSize()) {
+            contents.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(contents, pageable, hasNext);
+    }
+
+    public Study findMaxRecruitIdx() {
+        return queryFactory.selectFrom(study)
+                .orderBy(study.id.desc())
+                .fetchFirst();
+    }
+
+    //no-offset 방식 처리
+    private BooleanExpression ltStudyId(@Nullable Long studyId) {
+        return studyId == null ? null : study.id.lt(studyId);
+    }
+
+
+    //제목 검색어로 검색
+    private BooleanExpression titleLike(final String title) {
+        return StringUtils.hasText(title) ? study.title.contains(title) : null;
+    }
+
+    //카테고리로 필터링
+    private BooleanBuilder categoryEq(final List<Category> categoryList) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        if (categoryList.isEmpty()) return booleanBuilder;
+
+        for (Category category : categoryList) {
+            booleanBuilder.or(study.category.eq(category));
+        }
+
+        return booleanBuilder;
+    }
+}


### PR DESCRIPTION
## 작업 내용 :technologist:
- 카테고리 다중 선택을 통한 모집 공고 조회를 구현했습니다.
- 제목 검색 기능을 구현했습니다.
- 정렬순(최신순이 default, 모집마감일 순) 모집 공고 조회 기능을 구현했습니다.

## 반영 브랜치 :rocket:
recruitPage/xloyeon -> main

## To Reviewers :speech_balloon:
- 아직 찜 누르기 기능이 완료되지 않아 인기순 정렬은 구현하지 않았습니다.
- 자세한 내용은 노션 api 명세 페이지 참고해주세요.
