### PR TITLE
feat: 스터디 생성, 출석체크, 피드백 작성, 관리, 조회 구현

### DIFF
--- a/src/main/java/com/study/modoos/common/exception/ErrorCode.java
+++ b/src/main/java/com/study/modoos/common/exception/ErrorCode.java
@@ -14,18 +14,24 @@ public enum ErrorCode {
     WAITER_NOT_FOUND(HttpStatus.NOT_FOUND, "대기자 정보를 찾지 못했습니다.", "standbyId를 확인해주세요"),
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "email 또는 비밀번호가 맞지 않습니다.", "다른 이메일 또는 비밀번호를 사용해야합니다."),
     FORBIDDEN_ARTICLE(HttpStatus.FORBIDDEN, "게시글에 수정, 삭제에 대한 권한이 없습니다.", "잘못된 접근입니다. 입력값을 확인해주세요."),
-    FORBIDDEN_STUDY_ACCEPT(HttpStatus.FORBIDDEN, "스터디 신청에 수락 및 거절에 대한 권한이 없습니다.","잘못된 접근입니다. 스터디 리더인지 확인해주세요" ),
+    FORBIDDEN_STUDY_ACCEPT(HttpStatus.FORBIDDEN, "스터디 관리에 대한 권한이 없습니다.", "잘못된 접근입니다. 스터디 리더인지 확인해주세요"),
     ALREADY_MEMBER(HttpStatus.CONFLICT, "이미 존재하는 유저 정보입니다.", "다른 이메일 혹은 닉네임을 사용해야합니다."),
     ALREADY_PARTICIPANT(HttpStatus.CONFLICT, "해당 스터디에 이미 참여중입니다.", "다른 스터디를 신청해주세요"),
-    ALREADY_STANDBY(HttpStatus.CONFLICT, "해당 스터디에 이미 참여 신청하였습니다." , "다른 스터디 신청해주세요" ),
+    ALREADY_STANDBY(HttpStatus.CONFLICT, "해당 스터디에 이미 참여 신청하였습니다.", "다른 스터디 신청해주세요"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료됐거나 권한이 없습니다.", "토큰을 재발급 받아야합니다."),
     VALUE_NOT_IN_OPTION(HttpStatus.BAD_REQUEST, "선택지에 없는 값을 사용했습니다.", "선택지에 있는 값을 사용해야 합니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 comment id 입니다.", "올바른 comment id 인지 확인해주세요."),
     INVALID_WRITER(HttpStatus.UNAUTHORIZED, "댓글 작성자와 호출자(현재 사용자)의 정보가 다릅니다", "댓글 작성자를 확인해주세요"),
     INVALID_DELETE(HttpStatus.UNAUTHORIZED, "댓글 삭제자와 호출자(현재 사용자)의 정보가 다릅니다.", "댓글 삭제자를 확인해주세요"),
     INVALID_PARENT_ID(HttpStatus.UNAUTHORIZED, "부모 댓글의 스터디 공고글과 현재 작성하는 스터디 공고글이 다릅니다.", "부모 댓글 id를 확인해주세요"),
-    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트 항목을 찾을 수 있습니다.", "체크리스트 항목 id가 올바른지 확인해주세요."),
-    INVALID_STUDY(HttpStatus.NOT_FOUND, "해당 스터디의 참여 인원 정보를 가져올 수 없습니다." , "스터디의 참여인원이 있는지 확인해주세요");
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트 항목을 찾을 수 없습니다.", "체크리스트 항목 id가 올바른지 확인해주세요."),
+    INVALID_STUDY(HttpStatus.NOT_FOUND, "해당 스터디의 참여 인원 정보를 가져올 수 없습니다.", "스터디의 참여인원이 있는지 확인해주세요"),
+    MEMBER_NOT_IN_STUDY(HttpStatus.FORBIDDEN, "해당 스터디에 참여인원이 아닙니다.", "스터디에 참여중인지 확인해주세요."),
+    RECEIVER_NOT_IN_STUDY(HttpStatus.FORBIDDEN, "평가 회원이 해당 스터디에 참여 인원이 아닙니다.", "스터디에 참여중인지 확인해주세요"),
+    NOT_EVALUATION_PERIOD(HttpStatus.FORBIDDEN, "평기 기간이 아닙니다.", "평가기간을 다시 한 번 확인해주세요."),
+    MEMBER_IS_ABSENT(HttpStatus.FORBIDDEN, "결석한 참여자는 평가할 수 없습니다.", "이번 회차 출결을 확인해주세요."),
+    UNABLE_TO_START_ON_THE_DAY(HttpStatus.FORBIDDEN, "스터디 시작일은 당잉이 될 수 없습니다.", "스터디 시작일을 변경해주세요."),
+    ALREADY_FEEDBACK(HttpStatus.CONFLICT, "이미 평가하였습니다.", "평가 주차와 이전 평가 여부를 다시 한 번 확인해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/study/modoos/feedback/entity/Attendance.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Attendance.java
@@ -1,0 +1,37 @@
+package com.study.modoos.feedback.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum Attendance {
+    ATTEND("출석", 0),
+    LATE("지각", 1),
+    ABSENT("결석", 2);
+
+
+    private static final Map<String, Attendance> attendanceMap = Stream.of(values())
+            .collect(Collectors.toMap(Attendance::getKeyword, Function.identity()));
+
+    @JsonValue
+    private final String keyword;
+
+    private final int status;
+
+    @JsonCreator
+    public static Attendance resolve(String keyword) {
+        return Optional.ofNullable(attendanceMap.get(keyword))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
+}

--- a/src/main/java/com/study/modoos/feedback/entity/Feedback.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Feedback.java
@@ -36,17 +36,11 @@ public class Feedback extends BaseTimeEntity {
     @Column(name = "times")
     private int times;  //회차번호
 
-    @ColumnDefault("0")
-    @Column(name = "attend")
-    private int attend; //출석여부
-
-    @ColumnDefault("0")
-    @Column(name = "deligence")
-    private int deligence;  //규칙이행도
-
-    @ColumnDefault("0")
+    @ColumnDefault("1")
     @Column(name = "participate")
     private int participate;  //참여도
+
+    private boolean isReflected;    //해당 피드백이 점수에 반영되었는지 여부
 
     @Enumerated(EnumType.STRING)
     private Positive positive;
@@ -56,15 +50,14 @@ public class Feedback extends BaseTimeEntity {
 
     @Builder
     public Feedback(Study study, Participant receiver, Participant sender, int times,
-                    int attend, int deligence, int participate, Positive positive, Negative negative) {
+                    int participate, Positive positive, Negative negative) {
         this.study = study;
         this.receiver = receiver;
         this.sender = sender;
         this.times = times;
-        this.attend = attend;
-        this.deligence = deligence;
         this.participate = participate;
         this.positive = positive;
         this.negative = negative;
+        this.isReflected = false;
     }
 }

--- a/src/main/java/com/study/modoos/feedback/entity/FeedbackTodo.java
+++ b/src/main/java/com/study/modoos/feedback/entity/FeedbackTodo.java
@@ -1,0 +1,32 @@
+package com.study.modoos.feedback.entity;
+
+import com.study.modoos.study.entity.Todo;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "feedbackTodo")
+public class FeedbackTodo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todoId", referencedColumnName = "id")
+    private Todo todo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedbackId", referencedColumnName = "id")
+    private Feedback feedback;
+
+    @Builder
+    public FeedbackTodo(Todo todo, Feedback feedback) {
+        this.todo = todo;
+        this.feedback = feedback;
+    }
+}

--- a/src/main/java/com/study/modoos/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/study/modoos/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,17 @@
+package com.study.modoos.feedback.repository;
+
+import com.study.modoos.feedback.entity.Feedback;
+import com.study.modoos.participant.entity.Participant;
+import com.study.modoos.study.entity.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    List<Feedback> findByReceiverAndStudyAndTimes(Participant receiver, Study study, int times);
+
+    List<Feedback> findBySenderAndStudyAndTimes(Participant sender, Study study, int times);
+}

--- a/src/main/java/com/study/modoos/feedback/repository/FeedbackTodoRepository.java
+++ b/src/main/java/com/study/modoos/feedback/repository/FeedbackTodoRepository.java
@@ -1,0 +1,14 @@
+package com.study.modoos.feedback.repository;
+
+import com.study.modoos.feedback.entity.Feedback;
+import com.study.modoos.feedback.entity.FeedbackTodo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FeedbackTodoRepository extends JpaRepository<FeedbackTodo, Long> {
+
+    List<FeedbackTodo> findFeedbackTodoByFeedback(Feedback feedback);
+}

--- a/src/main/java/com/study/modoos/participant/controller/ParticipantController.java
+++ b/src/main/java/com/study/modoos/participant/controller/ParticipantController.java
@@ -8,7 +8,10 @@ import com.study.modoos.participant.response.StandbyResponse;
 import com.study.modoos.participant.service.ParticipantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,18 +21,18 @@ public class ParticipantController {
     private final ParticipantService participantService;
 
     @GetMapping("/apply/{studyId}")
-    public ResponseEntity<StandbyResponse> applyStudy (@CurrentUser Member member,
-                                                       @PathVariable(value = "studyId") Long studyId){
+    public ResponseEntity<StandbyResponse> applyStudy(@CurrentUser Member member,
+                                                      @PathVariable(value = "studyId") Long studyId) {
         return ResponseEntity.ok(participantService.applyStudy(member, studyId));
     }
 
     @GetMapping("/accept/{standbyId}")
-    public ResponseEntity<ParticipantResponse> acceptApplication (@CurrentUser Member member, @PathVariable Long standbyId) {
+    public ResponseEntity<ParticipantResponse> acceptApplication(@CurrentUser Member member, @PathVariable(value = "standbyId") Long standbyId) {
         return ResponseEntity.ok(participantService.acceptApplication(member, standbyId));
     }
 
     @GetMapping("/reject/{standbyId}")
-    public ResponseEntity<NormalResponse> rejectApplication(@CurrentUser Member member, @PathVariable Long standbyId) {
+    public ResponseEntity<NormalResponse> rejectApplication(@CurrentUser Member member, @PathVariable(value = "standbyId") Long standbyId) {
         participantService.rejectApplication(member, standbyId);
         return ResponseEntity.ok(NormalResponse.success());
     }

--- a/src/main/java/com/study/modoos/participant/entity/Participant.java
+++ b/src/main/java/com/study/modoos/participant/entity/Participant.java
@@ -1,10 +1,14 @@
 package com.study.modoos.participant.entity;
 
+import com.study.modoos.feedback.entity.Attendance;
 import com.study.modoos.member.entity.Member;
 import com.study.modoos.study.entity.Study;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -26,10 +30,37 @@ public class Participant {
     @JoinColumn(name = "study_id", referencedColumnName = "id")
     private Study study;
 
+    @Column
+    private List<Attendance> attendanceList = new ArrayList<>();
+
+    @ColumnDefault("0")
+    @Column(name = "absent")
+    private int absent;
+
+    @ColumnDefault("0")
+    @Column(name = "late")
+    private int late;
+
+    @ColumnDefault("0")
+    @Column(name = "outs")
+    private int out;
+
     @Builder
     public Participant(Member member, Study study) {
         this.member = member;
         this.study = study;
+    }
+
+    public void updateAbsent(int absent) {
+        this.absent = absent;
+    }
+
+    public void updateLate(int late) {
+        this.late = late;
+    }
+
+    public void updateOut(int out) {
+        this.out = out;
     }
 
     @Override

--- a/src/main/java/com/study/modoos/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/study/modoos/participant/repository/ParticipantRepository.java
@@ -5,8 +5,13 @@ import com.study.modoos.participant.entity.Participant;
 import com.study.modoos.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     boolean existsByStudyAndMember(Study study, Member currentUser);
 
-    Participant findByMemberAndStudy(Member member, Study study);
+    Optional<Participant> findByMemberAndStudy(Member member, Study study);
+
+    List<Participant> findByStudy(Study study);
 }

--- a/src/main/java/com/study/modoos/participant/repository/StandbyRepository.java
+++ b/src/main/java/com/study/modoos/participant/repository/StandbyRepository.java
@@ -5,6 +5,7 @@ import com.study.modoos.participant.entity.Standby;
 import com.study.modoos.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,6 +15,6 @@ public interface StandbyRepository extends JpaRepository<Standby, Long> {
     Standby findByMemberAndStudy(Member currentUser, Study study);
 
     @Query("SELECT s FROM Standby s JOIN FETCH s.member m JOIN FETCH s.study st WHERE s.id = :standbyId")
-    Optional<Standby> findWithMemberAndStudyById(Long standbyId);
+    Optional<Standby> findWithMemberAndStandbyId(@Param("standbyId") Long standbyId);
 }
 

--- a/src/main/java/com/study/modoos/participant/service/ParticipantService.java
+++ b/src/main/java/com/study/modoos/participant/service/ParticipantService.java
@@ -38,7 +38,7 @@ public class ParticipantService {
         if (isParticipant) {
             throw new ModoosException(ErrorCode.ALREADY_PARTICIPANT);
         }
-        if(isStandby){
+        if (isStandby) {
             throw new ModoosException(ErrorCode.ALREADY_STANDBY);
         }
         Standby standby = new Standby(currentUser, study);
@@ -50,19 +50,21 @@ public class ParticipantService {
     public ParticipantResponse acceptApplication(Member member, Long standbyId) {
         Member currentUser = memberRepository.findById(member.getId())
                 .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
-        Standby standby = standbyRepository.findWithMemberAndStudyById(standbyId)
+        Standby standby = standbyRepository.findWithMemberAndStandbyId(standbyId)
                 .orElseThrow(() -> new ModoosException(ErrorCode.WAITER_NOT_FOUND));
 
         Study study = standby.getStudy();
-        Member applicant  = standby.getMember();
+        Member applicant = standby.getMember();
 
-        if (!study.getLeader().equals(currentUser)){
+        if (!study.getLeader().equals(currentUser)) {
             throw new ModoosException(ErrorCode.FORBIDDEN_STUDY_ACCEPT);
         }
 
         Participant participant = new Participant(applicant, study);
         participantRepository.save(participant);
-        Participant participant_confirm = participantRepository.findByMemberAndStudy(applicant, study);
+        Participant participant_confirm = participantRepository.findByMemberAndStudy(applicant, study)
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY));
+
         standbyRepository.delete(standby);
 
         return ParticipantResponse.of(participant_confirm);
@@ -71,11 +73,11 @@ public class ParticipantService {
     public void rejectApplication(Member member, Long standbyId) {
         Member currentUser = memberRepository.findById(member.getId())
                 .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
-        Standby standby = standbyRepository.findWithMemberAndStudyById(standbyId)
+        Standby standby = standbyRepository.findWithMemberAndStandbyId(standbyId)
                 .orElseThrow(() -> new ModoosException(ErrorCode.WAITER_NOT_FOUND));
 
         Study study = standby.getStudy();
-        if (!study.getLeader().equals(currentUser)){
+        if (!study.getLeader().equals(currentUser)) {
             throw new ModoosException(ErrorCode.FORBIDDEN_STUDY_ACCEPT);
         }
 

--- a/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
+++ b/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
@@ -40,9 +40,10 @@ public class RecruitController {
     public ResponseEntity<Slice<RecruitListInfoResponse>> getRecruitList(@CurrentUser Member member,
                                                                          @RequestParam(value = "category", defaultValue = "") List<String> category,
                                                                          @RequestParam(value = "searchBy", required = false) String search,
+                                                                         @RequestParam(value = "lastId", required = false) Long lastId,
                                                                          @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
 
-        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, pageable));
+        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, lastId, pageable));
 
     }
 

--- a/src/main/java/com/study/modoos/recruit/request/ChangeRecruitRequest.java
+++ b/src/main/java/com/study/modoos/recruit/request/ChangeRecruitRequest.java
@@ -24,7 +24,6 @@ public class ChangeRecruitRequest {
     int late;
     int absent;
     int out;
-    String rule_content;
     String title;
     String description;
     List<TodoRequest> checkList;

--- a/src/main/java/com/study/modoos/recruit/request/RecruitRequest.java
+++ b/src/main/java/com/study/modoos/recruit/request/RecruitRequest.java
@@ -28,7 +28,6 @@ public class RecruitRequest {
     int late;
     int absent;
     int out;
-    String rule_content;
     String title;
     String description;
     List<String> checkList;
@@ -49,7 +48,6 @@ public class RecruitRequest {
                 .late(late)
                 .absent(absent)
                 .out(out)
-                .rule_content(rule_content)
                 .title(title)
                 .description(description)
                 .build();

--- a/src/main/java/com/study/modoos/recruit/service/RecruitService.java
+++ b/src/main/java/com/study/modoos/recruit/service/RecruitService.java
@@ -55,8 +55,12 @@ public class RecruitService {
         }
 
         studyRepository.save(study);
-      
-        Participant participant = new Participant(currentMember, study);
+
+        Participant participant = Participant.builder()
+                .member(currentMember)
+                .study(study)
+                .build();
+
         participantRepostiory.save(participant);
 
         return RecruitIdResponse.of(study);
@@ -76,14 +80,14 @@ public class RecruitService {
         return RecruitInfoResponse.of(study, false, checkList);
     }
 
-    public Slice<RecruitListInfoResponse> getRecruitList(Member member, String search, List<String> categoryList, Pageable pageable) {
+    public Slice<RecruitListInfoResponse> getRecruitList(Member member, String search, List<String> categoryList, Long lastId, Pageable pageable) {
 
         List<Category> categories = new ArrayList<>();
 
         for (String s : categoryList) {
             categories.add(Category.resolve(s));
         }
-        return studyRepositoryImpl.getSliceOfRecruit(member, search, categories, pageable);
+        return studyRepositoryImpl.getSliceOfRecruit(member, search, categories, lastId, pageable);
     }
 
     @Transactional
@@ -102,8 +106,8 @@ public class RecruitService {
         //스터디 모집공고 내용 update
         study.update(request.getCampus(), request.getChannel(), request.getCategory(),
                 request.getExpected_start_at(), request.getExpected_end_at(), request.getContact(),
-                request.getRule_content(), request.getTitle(), request.getDescription(),
-                request.getAbsent(), request.getLate(), request.getOut(), request.getRule_content());
+                request.getLink(), request.getTitle(), request.getDescription(),
+                request.getAbsent(), request.getLate(), request.getOut());
 
         //체크리스트 확인해서 update
         List<TodoRequest> checkList = request.getCheckList();

--- a/src/main/java/com/study/modoos/study/controller/StudyController.java
+++ b/src/main/java/com/study/modoos/study/controller/StudyController.java
@@ -1,0 +1,55 @@
+package com.study.modoos.study.controller;
+
+import com.study.modoos.common.CurrentUser;
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.recruit.response.RecruitIdResponse;
+import com.study.modoos.study.request.CreateAllAttendanceRequest;
+import com.study.modoos.study.request.CreateAllFeedbackRequest;
+import com.study.modoos.study.request.CreateStudyRequest;
+import com.study.modoos.study.response.BeforeFeedbackResponse;
+import com.study.modoos.study.response.CreateStudyResponse;
+import com.study.modoos.study.response.StudyInfoResponse;
+import com.study.modoos.study.service.StudyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study")
+public class StudyController {
+
+    private final StudyService studyService;
+
+    @GetMapping("/create/{id}")
+    public ResponseEntity<CreateStudyResponse> getCreateInfo(@CurrentUser Member member, @PathVariable(value = "id") Long id) {
+        return ResponseEntity.ok(studyService.beforeCreate(member, id));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<RecruitIdResponse> createStudy(@CurrentUser Member member, @RequestBody CreateStudyRequest request) {
+        return ResponseEntity.ok(studyService.createStudy(member, request));
+    }
+
+    @PostMapping("/attend/{id}")
+    public ResponseEntity<RecruitIdResponse> checkAttendance(@CurrentUser Member member, @PathVariable(value = "id") Long id,
+                                                             @RequestBody CreateAllAttendanceRequest request) {
+        return ResponseEntity.ok(studyService.checkAttendance(member, id, request));
+    }
+
+    @GetMapping("/feedback/{id}/{turn}")
+    public ResponseEntity<BeforeFeedbackResponse> getFeedbackInfo(@CurrentUser Member member, @PathVariable(value = "id") Long id,
+                                                                  @PathVariable(value = "turn") int turn) {
+        return ResponseEntity.ok(studyService.beforeFeedback(member, id, turn));
+    }
+
+    @PostMapping("/feedback/{id}")
+    public ResponseEntity<RecruitIdResponse> createFeedback(@CurrentUser Member member, @RequestBody CreateAllFeedbackRequest request) {
+        return ResponseEntity.ok(studyService.createFeedback(member, request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StudyInfoResponse> getStudyInfo(@CurrentUser Member member, @PathVariable(value = "id") Long id) {
+        return ResponseEntity.ok(studyService.getStudyInfo(member, id));
+    }
+}

--- a/src/main/java/com/study/modoos/study/entity/Study.java
+++ b/src/main/java/com/study/modoos/study/entity/Study.java
@@ -6,18 +6,17 @@ import com.study.modoos.member.entity.Campus;
 import com.study.modoos.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "study")
 public class Study extends BaseTimeEntity {
@@ -75,9 +74,6 @@ public class Study extends BaseTimeEntity {
     @Column(name = "link")
     private String link;
 
-    @Column(length = 2000)
-    private String rule_content;
-
     @ColumnDefault("0")
     @Column(name = "absent")
     private int absent;
@@ -90,15 +86,25 @@ public class Study extends BaseTimeEntity {
     @Column(name = "outs")
     private int out;
 
-    @Column(updatable = false)
+    @Column
     private LocalDate start_at;
 
-    @Column(updatable = false)
+    @Column
     private LocalDate end_at;
+
+    @Column
+    private LocalTime studyTime;
+
+    @Column
+    private LocalTime endTime;
 
     @ColumnDefault("0")
     @Column(name = "period")
     private int period;
+
+    @ColumnDefault("0")
+    @Column(name = "current_turn")
+    private int current_turn;
 
     @ColumnDefault("0")
     @Column(name = "total_turn")
@@ -112,7 +118,7 @@ public class Study extends BaseTimeEntity {
     public Study(Member leader, String title, String description, int recruits_count,
                  LocalDate recruit_deadline, Channel channel, LocalDate expected_start_at,
                  LocalDate expected_end_at, Category category, Campus campus, String contact,
-                 String link, String rule_content, int absent, int late, int out) {
+                 String link, int absent, int late, int out) {
         this.leader = leader;
         this.title = title;
         this.description = description;
@@ -126,7 +132,6 @@ public class Study extends BaseTimeEntity {
         this.campus = campus;
         this.contact = contact;
         this.link = link;
-        this.rule_content = rule_content;
         this.absent = absent;
         this.late = late;
         this.out = out;
@@ -135,7 +140,7 @@ public class Study extends BaseTimeEntity {
 
     public void update(Campus campus, Channel channel, Category category, LocalDate expected_start_at,
                        LocalDate expected_end_at, String contact, String link, String title, String description,
-                       int absent, int late, int out, String rule_content) {
+                       int absent, int late, int out) {
         this.title = title;
         this.description = description;
         this.channel = channel;
@@ -145,7 +150,6 @@ public class Study extends BaseTimeEntity {
         this.campus = campus;
         this.contact = contact;
         this.link = link;
-        this.rule_content = rule_content;
         this.absent = absent;
         this.late = late;
         this.out = out;
@@ -159,6 +163,27 @@ public class Study extends BaseTimeEntity {
      * 나중에 여기에 스터디 생성 시 진짜 시작일, 종료일, 회차, 기간 update하는 로직 넣기(생성자 새로 만들지 x)
      */
 
+    public void setStudy(LocalDate start_at, LocalDate end_at, LocalTime studyTime, LocalTime endTime,
+                         int period, int total_turn, int absent, int late, int out) {
+        this.start_at = start_at;
+        this.end_at = end_at;
+        this.studyTime = studyTime;
+        this.endTime = endTime;
+        this.period = period;
+        this.total_turn = total_turn;
+        this.absent = absent;
+        this.late = late;
+        this.out = out;
+        this.current_turn = 0;
+    }
+
+    public void updateStatus(int status) {
+        this.status = status;
+    }
+
+    public void updateCurrentTurn(int current_turn) {
+        this.current_turn = current_turn;
+    }
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
@@ -34,6 +34,7 @@ public class StudyRepositoryImpl {
     public Slice<RecruitListInfoResponse> getSliceOfRecruit(Member member,
                                                             final String title,
                                                             final List<Category> categoryList,
+                                                            Long lastId,
                                                             Pageable pageable) {
         /*
         if (order.equals("likeCount")) {
@@ -48,7 +49,8 @@ public class StudyRepositoryImpl {
         JPAQuery<Study> results = queryFactory.selectFrom(study)
                 .where(
                         titleLike(title),
-                        categoryEq(categoryList))
+                        categoryEq(categoryList),
+                        study.id.gt(lastId))
                 //.orderBy(study.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1);

--- a/src/main/java/com/study/modoos/study/request/CreateAllAttendanceRequest.java
+++ b/src/main/java/com/study/modoos/study/request/CreateAllAttendanceRequest.java
@@ -1,0 +1,14 @@
+package com.study.modoos.study.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAllAttendanceRequest {
+    private List<CreateOneAttendanceRequest> attendanceList;
+}

--- a/src/main/java/com/study/modoos/study/request/CreateAllFeedbackRequest.java
+++ b/src/main/java/com/study/modoos/study/request/CreateAllFeedbackRequest.java
@@ -1,0 +1,19 @@
+package com.study.modoos.study.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAllFeedbackRequest {
+    private Long id;    //어떤 스터디
+    private int turn;   //현재 평가하는 회차
+
+    private List<CreateOneFeedbackRequest> feedbackList;
+
+
+}

--- a/src/main/java/com/study/modoos/study/request/CreateOneAttendanceRequest.java
+++ b/src/main/java/com/study/modoos/study/request/CreateOneAttendanceRequest.java
@@ -1,0 +1,15 @@
+package com.study.modoos.study.request;
+
+import com.study.modoos.feedback.entity.Attendance;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOneAttendanceRequest {
+    private Long id;    //평가받는 회원 아이디
+
+    private Attendance attendance;
+}

--- a/src/main/java/com/study/modoos/study/request/CreateOneFeedbackRequest.java
+++ b/src/main/java/com/study/modoos/study/request/CreateOneFeedbackRequest.java
@@ -1,0 +1,24 @@
+package com.study.modoos.study.request;
+
+import com.study.modoos.feedback.entity.Negative;
+import com.study.modoos.feedback.entity.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOneFeedbackRequest {
+    private Long id;    //피드백 대상 아이디
+
+    private int participate;
+
+    private Positive positive;
+
+    private Negative negative;
+
+    private List<TodoIdResponse> checkList;
+}

--- a/src/main/java/com/study/modoos/study/request/CreateStudyRequest.java
+++ b/src/main/java/com/study/modoos/study/request/CreateStudyRequest.java
@@ -1,0 +1,33 @@
+package com.study.modoos.study.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateStudyRequest {
+    private Long id;
+
+    private LocalDate start_at;
+
+    private LocalDate end_at;
+
+    private LocalTime studyTime;
+
+    private LocalTime endTime;
+
+    private int period; //주기
+
+    private int total_turn; //총 회차
+
+    private int absent;
+
+    private int late;
+
+    private int out;
+}

--- a/src/main/java/com/study/modoos/study/request/TodoIdResponse.java
+++ b/src/main/java/com/study/modoos/study/request/TodoIdResponse.java
@@ -1,0 +1,14 @@
+package com.study.modoos.study.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TodoIdResponse {
+    private Long id;
+}

--- a/src/main/java/com/study/modoos/study/response/BeforeFeedbackResponse.java
+++ b/src/main/java/com/study/modoos/study/response/BeforeFeedbackResponse.java
@@ -1,0 +1,33 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.recruit.response.TodoResponse;
+import com.study.modoos.study.entity.Study;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BeforeFeedbackResponse {
+    private Long id;    //스터디 id
+    private int turn;   //현재 회차
+    private List<TodoResponse> checkList;   //체크리스트
+    private List<StudyParticipantResponse> participantResponseList; //참여자 list
+    private boolean isLeader;
+
+    public static BeforeFeedbackResponse of(Study study, List<TodoResponse> todoResponses, List<StudyParticipantResponse> participantResponseList,
+                                            boolean isLeader) {
+        return BeforeFeedbackResponse.builder()
+                .id(study.getId())
+                .turn(study.getCurrent_turn())
+                .checkList(todoResponses)
+                .participantResponseList(participantResponseList)
+                .isLeader(isLeader)
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/study/response/CheckTodoResponse.java
+++ b/src/main/java/com/study/modoos/study/response/CheckTodoResponse.java
@@ -1,0 +1,30 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.study.entity.Todo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CheckTodoResponse {
+
+    private Long id;
+
+    private String content;
+
+    private boolean isCheck;
+
+
+    public static CheckTodoResponse of(Todo todo, boolean isCheck) {
+        return CheckTodoResponse.builder()
+                .id(todo.getId())
+                .content(todo.getContent())
+                .isCheck(isCheck)
+                .build();
+    }
+
+}

--- a/src/main/java/com/study/modoos/study/response/CreateStudyResponse.java
+++ b/src/main/java/com/study/modoos/study/response/CreateStudyResponse.java
@@ -1,0 +1,39 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.recruit.response.TodoResponse;
+import com.study.modoos.study.entity.Study;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreateStudyResponse {
+    private Long id;
+    private String title;
+    private LocalDate expected_start_at;
+    private LocalDate expected_end_at;
+    private List<TodoResponse> checkList;
+    private int absent;
+    private int late;
+    private int out;
+
+    public static CreateStudyResponse of(Study study, List<TodoResponse> checkList) {
+        return CreateStudyResponse.builder()
+                .id(study.getId())
+                .title(study.getTitle())
+                .expected_start_at(study.getExpected_start_at())
+                .expected_end_at(study.getExpected_end_at())
+                .checkList(checkList)
+                .absent(study.getAbsent())
+                .late(study.getLate())
+                .out(study.getOut())
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/study/response/FeedbackResponse.java
+++ b/src/main/java/com/study/modoos/study/response/FeedbackResponse.java
@@ -1,0 +1,23 @@
+package com.study.modoos.study.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FeedbackResponse {
+
+    private int times;
+
+    private List<CheckTodoResponse> checkList;  //통과한 todo리스트
+
+    private List<PositiveKeywordResponse> positiveList;
+
+    private List<NegativeKeywordResponse> negativeList;
+}

--- a/src/main/java/com/study/modoos/study/response/NegativeKeywordResponse.java
+++ b/src/main/java/com/study/modoos/study/response/NegativeKeywordResponse.java
@@ -1,0 +1,17 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.feedback.entity.Negative;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NegativeKeywordResponse {
+    private int count;
+
+    private Negative negative;
+}

--- a/src/main/java/com/study/modoos/study/response/PositiveKeywordResponse.java
+++ b/src/main/java/com/study/modoos/study/response/PositiveKeywordResponse.java
@@ -1,0 +1,18 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.feedback.entity.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PositiveKeywordResponse {
+
+    private int count;
+
+    private Positive positive;
+}

--- a/src/main/java/com/study/modoos/study/response/StudyInfoResponse.java
+++ b/src/main/java/com/study/modoos/study/response/StudyInfoResponse.java
@@ -1,0 +1,74 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.recruit.response.TodoResponse;
+import com.study.modoos.study.entity.Study;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StudyInfoResponse {
+
+    private Long id;
+
+    private Long memberId;
+
+    private String title;
+
+    private String description;
+
+    private int participants_count;
+
+    private int absent;
+
+    private int late;
+
+    private int out;
+
+    private LocalDate start_at;
+
+    private LocalDate end_at;
+
+    private LocalTime studyTime;
+
+    private int period;
+
+    private int total_turn;
+
+    private List<TodoResponse> checkList;   //전체 todo리스트
+
+    //현재 회원이 지난 주차 피드백 respons 담기
+    private FeedbackResponse feedback;
+
+    private List<StudyParticipantResponse> participantList; //전체 회원의 출석상태, 아웃, 정보 ㅔ
+
+    public static StudyInfoResponse of(Study study, Member member, List<TodoResponse> checkList, FeedbackResponse feedback, List<StudyParticipantResponse> participantList) {
+        return StudyInfoResponse.builder()
+                .id(study.getId())
+                .memberId(member.getId())
+                .title(study.getTitle())
+                .description(study.getDescription())
+                .participants_count(study.getParticipants_count())
+                .absent(study.getAbsent())
+                .late(study.getLate())
+                .out(study.getOut())
+                .start_at(study.getStart_at())
+                .end_at(study.getEnd_at())
+                .studyTime(study.getStudyTime())
+                .period(study.getPeriod())
+                .total_turn(study.getTotal_turn())
+                .checkList(checkList)
+                .feedback(feedback)
+                .participantList(participantList)
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/study/response/StudyParticipantResponse.java
+++ b/src/main/java/com/study/modoos/study/response/StudyParticipantResponse.java
@@ -1,0 +1,32 @@
+package com.study.modoos.study.response;
+
+import com.study.modoos.feedback.entity.Attendance;
+import com.study.modoos.participant.entity.Participant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StudyParticipantResponse {
+    private List<Attendance> attendanceList;
+    private Long id;    //참가자 아이디
+    private String nickname;
+    private String ranking;
+    private int outCount;
+
+    public static StudyParticipantResponse of(Participant participant, List<Attendance> attendanceList) {
+        return StudyParticipantResponse.builder()
+                .id(participant.getMember().getId())
+                .nickname(participant.getMember().getNickname())
+                .ranking(participant.getMember().getRanking())
+                .outCount(participant.getOut())
+                .attendanceList(attendanceList)
+                .build();
+    }
+}

--- a/src/main/java/com/study/modoos/study/service/StudyService.java
+++ b/src/main/java/com/study/modoos/study/service/StudyService.java
@@ -1,0 +1,562 @@
+package com.study.modoos.study.service;
+
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
+import com.study.modoos.feedback.entity.*;
+import com.study.modoos.feedback.repository.FeedbackRepository;
+import com.study.modoos.feedback.repository.FeedbackTodoRepository;
+import com.study.modoos.member.entity.Member;
+import com.study.modoos.member.repository.MemberRepository;
+import com.study.modoos.participant.entity.Participant;
+import com.study.modoos.participant.repository.ParticipantRepository;
+import com.study.modoos.recruit.response.RecruitIdResponse;
+import com.study.modoos.recruit.response.TodoResponse;
+import com.study.modoos.study.entity.Study;
+import com.study.modoos.study.entity.Todo;
+import com.study.modoos.study.repository.StudyRepository;
+import com.study.modoos.study.repository.TodoRepository;
+import com.study.modoos.study.request.*;
+import com.study.modoos.study.response.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class StudyService {
+    private final ParticipantRepository participantRepository;
+    private final StudyRepository studyRepository;
+
+    private final TodoRepository todoRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final FeedbackRepository feedbackRepository;
+
+    private final FeedbackTodoRepository feedbackTodoRepository;
+
+    //스터디 생성 전 스터디 설정 정보 넘겨받기
+    public CreateStudyResponse beforeCreate(Member currentMember, Long id) {
+        Study study = findStudy(id);
+
+        //study에 매핑된 todo 리스트 모두 가져오기
+        List<TodoResponse> checkList = findTodoOfStudy(study);
+
+        //리더면 생성 가능, 리더가 아니면 불가능
+        if (isLeaderOfStudy(currentMember, study)) {
+            return CreateStudyResponse.of(study, checkList);
+        } else {
+            throw new ModoosException(ErrorCode.FORBIDDEN_ARTICLE);
+        }
+    }
+
+    //스터디 생성하기
+    @Transactional
+    public RecruitIdResponse createStudy(Member currentMember, CreateStudyRequest request) {
+        Study study = findStudy(request.getId());
+
+        if (!isLeaderOfStudy(currentMember, study)) {
+            throw new ModoosException(ErrorCode.FORBIDDEN_ARTICLE);
+        }
+
+        //적어도 다음날 시작해야 함
+        if (request.getStart_at().equals(LocalDate.now()))
+            throw new ModoosException(ErrorCode.UNABLE_TO_START_ON_THE_DAY);
+
+        study.setStudy(request.getStart_at(), request.getEnd_at(), request.getStudyTime(),
+                request.getEndTime(), request.getPeriod(), request.getTotal_turn(),
+                request.getAbsent(), request.getLate(), request.getOut());
+        study.updateStatus(2);  //스터디 생성 완료 상태로 변경
+        studyRepository.save(study);
+        return RecruitIdResponse.of(study);
+    }
+
+    //리더만 출석 체크
+    @Transactional
+    public RecruitIdResponse checkAttendance(Member currentMember, Long id, CreateAllAttendanceRequest request) {
+        //스터디 찾기
+        Study study = findStudy(id);
+
+        //스터디 리더인지 확인
+        if (!isLeaderOfStudy(currentMember, study))
+            throw new ModoosException(ErrorCode.FORBIDDEN_STUDY_ACCEPT);
+
+        //현재 시간 확인하고 출석체크 기간인지 확인
+        LocalDateTime current = LocalDateTime.now();
+        log.info(current + "시간입니다.");
+        boolean isEvaluation = isAttendanceCheckPeriod(current, study);
+
+        if (!isEvaluation)
+            throw new ModoosException(ErrorCode.NOT_EVALUATION_PERIOD);
+
+        log.info("평가기간입니다");
+
+
+        //리더가 맞고 출석 체크 시간이 맞으면 출석 체크 저장
+        for (CreateOneAttendanceRequest oneAttendance : request.getAttendanceList()) {
+            Member tempMember = memberRepository.findById(oneAttendance.getId())
+                    .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
+
+            Participant participant = participantRepository.findByMemberAndStudy(tempMember, study)
+                    .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY));
+
+            //참가자의 출석 현황 리스트에 출석 저장
+            participant.getAttendanceList().add(oneAttendance.getAttendance());
+            log.info(String.valueOf(participant.getAttendanceList().size()));
+            log.info("출석을 저장했습니다.");
+
+            //지각이거나 결석이면 지각수와 결석수 update
+            if (oneAttendance.getAttendance().equals(Attendance.LATE))
+                participant.updateLate(participant.getLate() + 1);
+            else if (oneAttendance.getAttendance().equals(Attendance.ABSENT))
+                participant.updateAbsent(participant.getAbsent() + 1);
+
+            //지각부터 처리
+            while (participant.getLate() >= study.getLate()) {
+                participant.updateLate(participant.getLate() - study.getLate());
+                participant.updateAbsent(participant.getAbsent() + 1);
+            }
+
+            //결석 처리
+            while (participant.getAbsent() >= study.getAbsent()) {
+                participant.updateAbsent(participant.getAbsent() - study.getAbsent());
+                participant.updateAbsent(participant.getOut() + 1);
+            }
+
+            //참가자의 outcount가 넘으면 퇴출
+            if (participant.getOut() >= study.getOut()) {
+                participantRepository.delete(participant);
+                study.setParticipants_count(study.getParticipants_count() - 1);
+                continue;
+            }
+
+            participantRepository.save(participant);
+        }
+
+        return RecruitIdResponse.of(study);
+    }
+
+
+    //스터디 피드백 전에 피드백 해야 할 출석,지각한 참여자 정보, 체크리스트 정보 넘겨주기
+    public BeforeFeedbackResponse beforeFeedback(Member currentMember, Long id, int turn) {
+        //스터디 찾기
+        Study study = findStudy(id);
+
+        if (currentMember == null) {
+            throw new ModoosException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        //평가 기간인지 확인
+        LocalDateTime current = LocalDateTime.now();
+        boolean isEvaluation = isEvalutationPeriod(current, study);
+
+        if (!isEvaluation)
+            throw new ModoosException(ErrorCode.NOT_EVALUATION_PERIOD);
+
+        List<Participant> participantList = participantRepository.findByStudy(study);
+        boolean isParticipant = false;
+
+
+        //결석 인원 지우기
+        for (int i = 0; i < participantList.size(); i++) {
+            Participant participant = participantList.get(i);
+
+            //결석인원이면 참여자 리스트에서 지우기
+            if (participant.getAttendanceList().get(study.getCurrent_turn() - 1).equals(Attendance.ABSENT)) {
+                participantList.remove(participant);
+                i--;
+
+                //결석인원이 현재 자기자신이면 에러 메시지
+                if (participant.getMember().getId() == currentMember.getId())
+                    throw new ModoosException(ErrorCode.MEMBER_IS_ABSENT);
+
+            } else if (participant.getMember().getId() == currentMember.getId()) { //참여자이면
+                isParticipant = true;
+                participantList.remove(participant);    //참여자면 자기 자신도 지우
+                i--;
+            }
+        }
+
+        //아예 해당 스터디에 참여자가 아닐경우 에러 메시지
+        if (!isParticipant)
+            throw new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY);
+
+        Participant thisParticipant = participantRepository.findByMemberAndStudy(currentMember, study)
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY));
+
+        List<Feedback> feedbackOptional = feedbackRepository.findBySenderAndStudyAndTimes(thisParticipant, study, turn);
+        log.info(String.valueOf(feedbackOptional.size()));
+
+        //만약 이미 이번 주차 피드백을 한 상태라면
+        if (feedbackOptional.size() > 0) {
+            throw new ModoosException(ErrorCode.ALREADY_FEEDBACK);
+        }
+
+        //참여자의 정보 확인해서 넣기
+        List<StudyParticipantResponse> participantResponseList = new ArrayList<>();
+
+        for (Participant participant : participantList) {
+            ArrayList<Attendance> attendanceList = new ArrayList<>(participant.getAttendanceList());
+            List<Attendance> subList = attendanceList.subList(0, study.getCurrent_turn());
+            participantResponseList.add(StudyParticipantResponse.of(participant, subList));
+        }
+
+        //체크리스트 response 매핑
+        List<TodoResponse> checkList = findTodoOfStudy(study);
+
+        //리더면 리더라고 알려주기
+        if (isLeaderOfStudy(currentMember, study))
+            return BeforeFeedbackResponse.of(study, checkList, participantResponseList, true);
+        return BeforeFeedbackResponse.of(study, checkList, participantResponseList, false);
+    }
+
+    //피드백 저장하기
+    @Transactional
+    public RecruitIdResponse createFeedback(Member currentMember, CreateAllFeedbackRequest request) {
+        //스터디 있는지 확인
+        Study study = findStudy(request.getId());
+
+        if (currentMember == null)
+            throw new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY);
+
+        Member member = memberRepository.findById(currentMember.getId())
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
+
+        //feedback 생성자
+        Participant sender = participantRepository.findByMemberAndStudy(member, study)
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY));
+
+        //평가 기간인지 확인
+        LocalDateTime current = LocalDateTime.now();
+        boolean isEvaluation = isEvalutationPeriod(current, study);
+
+        if (!isEvaluation) {
+            throw new ModoosException(ErrorCode.NOT_EVALUATION_PERIOD);
+        }
+
+        //만약 생성자가 이번 주차 결석자면 평가 금지
+        if (sender.getAttendanceList().get(request.getTurn() - 1).equals(Attendance.ABSENT))
+            throw new ModoosException(ErrorCode.MEMBER_IS_ABSENT);
+
+
+        List<CreateOneFeedbackRequest> feedbackRequestList = request.getFeedbackList();
+
+        for (CreateOneFeedbackRequest feedbackRequest : feedbackRequestList) {
+            Member tempMember = memberRepository.findById(feedbackRequest.getId())
+                    .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
+
+            //receiver 확인
+            Participant receiver = participantRepository.findByMemberAndStudy(tempMember, study)
+                    .orElseThrow(() -> new ModoosException(ErrorCode.RECEIVER_NOT_IN_STUDY));
+
+            //checkList 확인 -> 안 한 것 저장
+            List<TodoIdResponse> todoList = feedbackRequest.getCheckList();
+
+            Feedback feedback = Feedback.builder()
+                    .study(study)
+                    .receiver(receiver)
+                    .sender(sender)
+                    .times(request.getTurn())
+                    .participate(feedbackRequest.getParticipate())
+                    .positive(feedbackRequest.getPositive())
+                    .negative(feedbackRequest.getNegative())
+                    .build();
+
+            for (TodoIdResponse todoResponse : todoList) {
+                Todo todo = todoRepository.findById(todoResponse.getId())
+                        .orElseThrow(() -> new ModoosException(ErrorCode.TODO_NOT_FOUND));
+                FeedbackTodo feedbackTodo = FeedbackTodo.builder()
+                        .todo(todo)
+                        .feedback(feedback)
+                        .build();
+                feedbackTodoRepository.save(feedbackTodo);
+            }
+            feedbackRepository.save(feedback);
+
+        }
+
+        return RecruitIdResponse.of(study);
+    }
+
+    //스터디 관리 페이지 조회
+    //만약 평가 기간이 끝났다면 -> 끝난 주차에 대한 값을 보여줘야 함
+    //만약 평가 가긴 중이라면 -> 현재 평가 기간 이전 주차에 대한 값을 보여줘야 함
+    public StudyInfoResponse getStudyInfo(Member currentMember, Long id) {
+
+        //스터디 id로 찾기
+        Study study = findStudy(id);
+
+        //로그인 한 사용자 검증
+        if (currentMember == null)
+            throw new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY);
+
+        //회원인지 검증
+        Member member = memberRepository.findById(currentMember.getId())
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_FOUND));
+
+        //스터디 참여 인원인지 검증
+        Participant thisParticipant = participantRepository.findByMemberAndStudy(currentMember, study)
+                .orElseThrow(() -> new ModoosException(ErrorCode.RECEIVER_NOT_IN_STUDY));
+
+//        List<StudyParticipantResponse> ifNotStartResponse = new ArrayList<>();
+//        List<Participant> participantList = participantRepository.findByStudy(study);
+//
+//        for (Participant participant : participantList) {
+//            ifNotStartResponse.add(StudyParticipantResponse.of(participant, new ArrayList<>()));
+//        }
+
+        //현재까지의 스터디
+        LocalDateTime current = LocalDateTime.now();
+        boolean isEvaluation = isEvalutationPeriod(current, study);
+
+
+        LocalDateTime startTime = study.getStart_at().atTime(study.getEndTime()).plusDays(1);
+        int idx = 0;
+
+        //시작 전이면 idx = 0, 평가기간 주차와 idx는 같아짐
+        for (LocalDateTime time = startTime; time.isEqual(study.getEnd_at().atTime(study.getEndTime()).plusDays(1)) || time.isBefore(study.getEnd_at().atTime(study.getEndTime()).plusDays(1));
+             time = time.plusDays(study.getPeriod() * 7)) {
+            LocalDateTime end = time.plusDays(study.getPeriod() * 7);
+            idx++;
+
+            if ((current.isEqual(time) || current.isAfter(time)) && current.isBefore(end)) {
+                break;
+            } else if (current.isBefore(time)) {
+                idx--;
+                break;
+            }
+        }
+
+        log.info(String.valueOf(idx));
+        //전체 todo 리스트
+        List<Todo> todoList = todoRepository.findTodoByStudy(study);
+        List<TodoResponse> todoResponseList = new ArrayList<>();
+
+        for (Todo todo : todoList) {
+            todoResponseList.add(TodoResponse.of(todo));
+        }
+
+        //전체 참여자 리스트
+        List<Participant> participants = participantRepository.findByStudy(study);
+        log.debug(String.valueOf(participants.size()));
+
+        //전체 회원의 출석상태, 아웃, 정보 가져오기
+        List<StudyParticipantResponse> studyParticipantResponseList = new ArrayList<>();
+
+        for (Participant participant : participants) {
+            ArrayList<Attendance> attendanceList = new ArrayList<>(participant.getAttendanceList());
+            log.info(String.valueOf(attendanceList.size()));
+
+            studyParticipantResponseList.add(StudyParticipantResponse.of(participant, attendanceList.subList(0, idx)));
+        }
+
+        if (idx == 0) {
+            return StudyInfoResponse.of(study, member, todoResponseList, null, studyParticipantResponseList);
+        }
+
+
+        //이번 주차에 받은 피드백 리스트
+        List<Feedback> feedbacks = new ArrayList<>();
+        int len = feedbacks.size() / 2;
+
+
+        //결석회원이면 피드백 안 보여줌
+        if (thisParticipant.getAttendanceList().get(idx - 1).equals(Attendance.ABSENT)) {
+            return StudyInfoResponse.of(study, member, todoResponseList, null, studyParticipantResponseList);
+        }
+
+        feedbacks = feedbackRepository.findByReceiverAndStudyAndTimes(thisParticipant, study, idx);
+
+
+        HashMap<Long, Integer> countMap = new HashMap<>();
+        HashMap<Positive, Integer> positiveMap = new HashMap<>();
+        HashMap<Negative, Integer> negativeMap = new HashMap<>();
+
+        for (Todo todo : todoList) {
+            countMap.put(todo.getId(), 0);
+        }
+
+        for (Feedback feedback : feedbacks) {
+            List<FeedbackTodo> feedbackTodoList = feedbackTodoRepository.findFeedbackTodoByFeedback(feedback);
+
+            for (FeedbackTodo feedbackTodo : feedbackTodoList) {
+                countMap.put(feedbackTodo.getTodo().getId(), countMap.get(feedbackTodo.getTodo().getId()) + 1);
+            }
+
+            if (feedback.getPositive() != null) {
+                if (positiveMap.containsKey(feedback.getPositive())) {
+                    positiveMap.put(feedback.getPositive(), positiveMap.get(feedback.getPositive()) + 1);
+                } else {
+                    positiveMap.put(feedback.getPositive(), 1);
+                }
+            }
+
+            if (feedback.getNegative() != null) {
+                if (negativeMap.containsKey(feedback.getNegative())) {
+                    negativeMap.put(feedback.getNegative(), negativeMap.get(feedback.getNegative()) + 1);
+                } else {
+                    negativeMap.put(feedback.getNegative(), 1);
+                }
+            }
+        }
+
+        List<CheckTodoResponse> checkTodoResponses = new ArrayList<>();
+
+        for (Todo todo : todoList) {
+            if (countMap.get(todo.getId()) > len) {
+                checkTodoResponses.add(CheckTodoResponse.of(todo, true));
+            } else {
+                checkTodoResponses.add(CheckTodoResponse.of(todo, false));
+            }
+        }
+
+        Set<Positive> positiveSet = positiveMap.keySet();
+        Set<Negative> negativeSet = negativeMap.keySet();
+
+        List<PositiveKeywordResponse> positiveKeywordResponses = new ArrayList<>();
+        List<NegativeKeywordResponse> negativeKeywordResponses = new ArrayList<>();
+
+        for (Positive positive : positiveSet) {
+            positiveKeywordResponses.add(PositiveKeywordResponse.builder()
+                    .count(positiveMap.get(positive))
+                    .positive(positive)
+                    .build());
+        }
+
+        for (Negative negative : negativeSet) {
+            negativeKeywordResponses.add(NegativeKeywordResponse.builder()
+                    .count(negativeMap.get(negative))
+                    .negative(negative)
+                    .build());
+        }
+
+        Collections.sort(positiveKeywordResponses, (o1, o2) -> {
+            return o2.getCount() - o1.getCount();
+        });
+
+        Collections.sort(negativeKeywordResponses, (o1, o2) -> {
+            return o2.getCount() - o1.getCount();
+        });
+
+        FeedbackResponse feedbackResponse = FeedbackResponse.builder()
+                .times(idx)
+                .checkList(checkTodoResponses)
+                .positiveList(positiveKeywordResponses)
+                .negativeList(negativeKeywordResponses)
+                .build();
+
+        if (feedbacks.size() == 0)
+            return StudyInfoResponse.of(study, member, todoResponseList, null, studyParticipantResponseList);
+
+        return StudyInfoResponse.of(study, member, todoResponseList, feedbackResponse, studyParticipantResponseList);
+    }
+
+    public void fillEmptyAttendance(Study study, int idx, boolean isEvaluation) {
+        //지금 현재 turn으로 update 시켜주고 빈 곳이 있으면 채워주기
+        Member leader = study.getLeader();
+
+        Participant self = participantRepository.findByMemberAndStudy(leader, study)
+                .orElseThrow(() -> new ModoosException(ErrorCode.MEMBER_NOT_IN_STUDY));
+
+        List<Participant> participantList = participantRepository.findByStudy(study);
+
+        //출결체크 못한 회차들 확인
+        if (self.getAttendanceList().size() + 1 < idx) {
+            int start = self.getAttendanceList().size();
+
+            for (Participant participant : participantList) {
+                for (int i = start + 1; i < idx; i++) {
+                    participant.getAttendanceList().add(Attendance.ATTEND);
+                }
+
+                if (!isEvaluation)   //평가 기간이 아니면 더해줘야 함
+                    participant.getAttendanceList().add(Attendance.ATTEND);
+                participantRepository.save(participant);
+            }
+        }
+
+        //current_turn을 update
+        study.updateCurrentTurn(idx);
+        studyRepository.save(study);
+    }
+
+    public Study findStudy(Long id) {
+        return studyRepository.findById(id)
+                .orElseThrow(() -> new ModoosException(ErrorCode.STUDY_NOT_FOUND));
+    }
+
+    public boolean isLeaderOfStudy(Member currentMember, Study study) {
+        return currentMember != null && study.getLeader().getId() == currentMember.getId();
+    }
+
+    public List<TodoResponse> findTodoOfStudy(Study study) {
+        return todoRepository.findTodoByStudy(study)
+                .stream().map(o -> TodoResponse.of(o))
+                .collect(Collectors.toList());
+    }
+
+    public boolean isEvalutationPeriod(LocalDateTime current, Study study) {
+        //평가 기간인지 확인
+        LocalDateTime startTime = study.getStart_at().atTime(study.getEndTime());
+        boolean isEvaluation = false;
+        int idx = 0;
+
+        for (LocalDateTime time = startTime; time.isEqual(study.getEnd_at().atTime(study.getEndTime())) || time.isBefore(study.getEnd_at().atTime(study.getEndTime()));
+             time = time.plusDays(study.getPeriod() * 7)) {
+            LocalDateTime end = time.plusDays(1);
+            idx++;
+
+            if ((current.isEqual(time) || current.isAfter(time)) && current.isBefore(end)) {
+                isEvaluation = true;
+                break;
+            } else if (current.isBefore(time)) {
+                idx--;
+                break;
+            }
+        }
+
+        fillEmptyAttendance(study, idx, isEvaluation);
+        return isEvaluation;
+    }
+
+    public boolean isAttendanceCheckPeriod(LocalDateTime current, Study study) {
+        LocalDateTime startTime = study.getStart_at().atTime(study.getStudyTime());
+        boolean isEvaluation = false;
+        int idx = 0;
+
+
+        //평가 기간인지 확인
+        for (LocalDateTime time = startTime; time.isEqual(study.getEnd_at().atTime(study.getStudyTime())) || time.isBefore(study.getEnd_at().atTime(study.getStudyTime()));
+             time = time.plusDays(study.getPeriod() * 7)) {
+
+            LocalDateTime end = time.withHour(study.getEndTime().getHour())
+                    .withMinute(study.getEndTime().getMinute())
+                    .withSecond(study.getEndTime().getSecond());
+
+            log.info(time + "부터 " + end + "안인지 확인");
+
+            idx++;
+
+            if ((current.isEqual(time) || current.isAfter(time)) && current.isBefore(end)) {
+                isEvaluation = true;
+                break;
+            } else if (current.isBefore(time)) {
+                idx--;
+                break;
+            }
+        }
+
+        fillEmptyAttendance(study, idx, isEvaluation);
+        return isEvaluation;
+    }
+
+
+}


### PR DESCRIPTION
## 작업 내용 :technologist:
- 스터디 공고 글에서의 작성 내용을 확인하고 생성 시 수정 가능하도록 했습니다.
- 리더는 매주 스터디 시작~ 스터디 종료 시간까지 출석체크를 할 수 있습니다.
- 결석한 회원은 피드백을 할 수 없으며, 결석한 회원을 대상으로도 피드백을 할 수 없습니다.
- 참여자들은 매주 피드백해야할 회원 리스트를 피드백 작성 이전에 확인합니다.
- 참여자들은 스터디 종료 시간~24시간까지만 피드백을 작성할 수 있으며, 그 주차의 피드백은 그 이후로 반영됩니다.
- 만약 아웃 카운트가 스터디의 아웃 카운트와 일치하게 되면 참여자는 자동으로 스터디에서 삭제됩니다.

## 반영 브랜치 :rocket:
createStudy/xloyeon -> main

## To Reviewers :speech_balloon:
- 매주 피드백에서 받은 참여도 평균 값과 피드백 안 한 회원에 대해 감점되는 신용점수는 아직 구현하지 않았습니다.
