### PR TITLE
feat : 스터디 점수 반영 및 무한 스크롤 수정

### DIFF
--- a/src/main/java/com/study/modoos/feedback/entity/Feedback.java
+++ b/src/main/java/com/study/modoos/feedback/entity/Feedback.java
@@ -35,11 +35,12 @@ public class Feedback extends BaseTimeEntity {
     @ColumnDefault("0")
     @Column(name = "times")
     private int times;  //회차번호
-    
+
     @ColumnDefault("1")
     @Column(name = "participate")
     private int participate;  //참여도
 
+    @Column(name = "isReflected")
     private boolean isReflected;    //해당 피드백이 점수에 반영되었는지 여부
 
     @Enumerated(EnumType.STRING)
@@ -60,5 +61,9 @@ public class Feedback extends BaseTimeEntity {
         this.positive = positive;
         this.negative = negative;
         this.isReflected = false;
+    }
+
+    public void updateIsReflected() {
+        this.isReflected = true;
     }
 }

--- a/src/main/java/com/study/modoos/member/entity/Member.java
+++ b/src/main/java/com/study/modoos/member/entity/Member.java
@@ -103,4 +103,29 @@ public class Member {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateScore(Long score) {
+        if (score < 0) {
+            this.score = 0L;
+        }
+        this.score = score;
+    }
+
+    public void updateRanking() {
+        if (this.score >= 1000) {
+            this.ranking = "S+";
+        } else if (this.score >= 800) {
+            this.ranking = "S";
+        } else if (this.score >= 600) {
+            this.ranking = "A+";
+        } else if (this.score >= 400) {
+            this.ranking = "A";
+        } else if (this.score >= 200) {
+            this.ranking = "B";
+        } else if (this.score >= 50) {
+            this.ranking = "C";
+        } else {
+            this.ranking = "?";
+        }
+    }
 }

--- a/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
+++ b/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
@@ -10,8 +10,10 @@ import com.study.modoos.recruit.response.RecruitInfoResponse;
 import com.study.modoos.recruit.response.RecruitListInfoResponse;
 import com.study.modoos.recruit.service.RecruitService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -43,7 +45,18 @@ public class RecruitController {
                                                                          @RequestParam(value = "lastId", required = false) Long lastId,
                                                                          @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
 
-        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, lastId, pageable));
+        Sort.Direction direction;
+
+        if (pageable.getSort().stream().anyMatch(o -> o.getProperty().equals("recruit_deadLine"))) {
+            direction = Sort.Direction.ASC;
+        } else {
+            direction = DESC;
+        }
+
+        Sort sort = Sort.by(new Sort.Order(direction, pageable.getSort().toString()));
+
+        Pageable pageableWithSort = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, lastId, pageableWithSort));
 
     }
 
@@ -60,7 +73,7 @@ public class RecruitController {
 
     @GetMapping("/my")
     public ResponseEntity<Slice<RecruitListInfoResponse>> getMyStudyList(@CurrentUser Member member,
-                                                                     @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+                                                                         @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
         return ResponseEntity.ok(recruitService.getMyStudyList(member, pageable));
     }
 }

--- a/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
@@ -4,6 +4,7 @@ import com.study.modoos.member.entity.Campus;
 import com.study.modoos.study.entity.Category;
 import com.study.modoos.study.entity.Channel;
 import com.study.modoos.study.entity.Study;
+import com.study.modoos.study.entity.StudyStatus;
 import com.study.modoos.study.response.StudyParticipantResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +31,7 @@ public class RecruitInfoResponse {
 
     private String description;
 
-    private int status;
+    private StudyStatus status;
 
     private Category category;
 
@@ -58,6 +59,12 @@ public class RecruitInfoResponse {
 
     private List<StudyParticipantResponse> participantList;
 
+    private int late;
+
+    private int absent;
+
+    private int out;
+
     public static RecruitInfoResponse of(Study study, boolean isWritten, List<TodoResponse> checkList,
                                          List<StudyParticipantResponse> participantList) {
         return RecruitInfoResponse.builder()
@@ -81,6 +88,9 @@ public class RecruitInfoResponse {
                 .isWritten(isWritten)
                 .checkList(checkList)
                 .participantList(participantList)
+                .late(study.getLate())
+                .absent(study.getAbsent())
+                .out(study.getOut())
                 .build();
     }
 }

--- a/src/main/java/com/study/modoos/recruit/response/RecruitListInfoResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitListInfoResponse.java
@@ -2,6 +2,7 @@ package com.study.modoos.recruit.response;
 
 import com.study.modoos.study.entity.Category;
 import com.study.modoos.study.entity.Study;
+import com.study.modoos.study.entity.StudyStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class RecruitListInfoResponse {
 
     private String title;
 
-    private int status;
+    private StudyStatus status;
 
     private Category category;
 

--- a/src/main/java/com/study/modoos/recruit/service/RecruitService.java
+++ b/src/main/java/com/study/modoos/recruit/service/RecruitService.java
@@ -47,12 +47,15 @@ public class RecruitService {
         Study study = request.createRecruit(currentMember);
         studyRepository.save(study);
 
-        for (String todo : todos) {
-            Todo t = Todo.builder().
-                    study(study)
-                    .content(todo)
-                    .build();
-            todoRepository.save(t);
+        if (todos != null) {
+
+            for (String todo : todos) {
+                Todo t = Todo.builder().
+                        study(study)
+                        .content(todo)
+                        .build();
+                todoRepository.save(t);
+            }
         }
 
         studyRepository.save(study);

--- a/src/main/java/com/study/modoos/recruit/service/RecruitService.java
+++ b/src/main/java/com/study/modoos/recruit/service/RecruitService.java
@@ -15,6 +15,7 @@ import com.study.modoos.recruit.response.RecruitListInfoResponse;
 import com.study.modoos.recruit.response.TodoResponse;
 import com.study.modoos.study.entity.Category;
 import com.study.modoos.study.entity.Study;
+import com.study.modoos.study.entity.StudyStatus;
 import com.study.modoos.study.entity.Todo;
 import com.study.modoos.study.repository.StudyRepository;
 import com.study.modoos.study.repository.StudyRepositoryImpl;
@@ -110,7 +111,7 @@ public class RecruitService {
         }
 
         //스터디가 이미 생성된 모집공고면 삭제 불가능
-        if (study.getStatus() == 2) {
+        if (study.getStatus() == StudyStatus.ONGOING) {
             throw new ModoosException(ErrorCode.STUDY_NOT_EDIT);
         }
 
@@ -159,7 +160,7 @@ public class RecruitService {
         }
 
         //스터디가 이미 생성된 모집공고면 삭제 불가능
-        if (study.getStatus() == 2) {
+        if (study.getStatus() == StudyStatus.ONGOING) {
             throw new ModoosException(ErrorCode.STUDY_NOT_EDIT);
         }
 

--- a/src/main/java/com/study/modoos/study/entity/Study.java
+++ b/src/main/java/com/study/modoos/study/entity/Study.java
@@ -46,9 +46,8 @@ public class Study extends BaseTimeEntity {
     private int participants_count;
 
     //0이면 모집중, 1이면 모집완료, 2면 스터디 생성 완료
-    @ColumnDefault("0")
-    @Column(name = "status")
-    private int status;
+    @Enumerated(EnumType.STRING)
+    private StudyStatus status;
 
     @Column(nullable = false)
     private LocalDate recruit_deadline;
@@ -76,7 +75,7 @@ public class Study extends BaseTimeEntity {
 
     @ColumnDefault("0")
     @Column(name = "absent")
-    private int absent;
+    private int absent;     //0이면 스터디 모집중, 1이면 스터디 모집마감, 2면 스터디 진행 중, 3번 스터디 종
 
     @ColumnDefault("0")
     @Column(name = "late")
@@ -114,6 +113,9 @@ public class Study extends BaseTimeEntity {
     @OrderBy("id asc")
     private List<Comment> comments;
 
+    @Column(name = "isEnd")
+    private boolean isEnd;
+
     @Builder
     public Study(Member leader, String title, String description, int recruits_count,
                  LocalDate recruit_deadline, Channel channel, LocalDate expected_start_at,
@@ -135,7 +137,7 @@ public class Study extends BaseTimeEntity {
         this.absent = absent;
         this.late = late;
         this.out = out;
-        this.status = 0;
+        this.status = StudyStatus.RECRUITING;
     }
 
     public void update(Campus campus, Channel channel, Category category, LocalDate expected_start_at,
@@ -177,12 +179,16 @@ public class Study extends BaseTimeEntity {
         this.current_turn = 0;
     }
 
-    public void updateStatus(int status) {
+    public void updateStatus(StudyStatus status) {
         this.status = status;
     }
 
     public void updateCurrentTurn(int current_turn) {
         this.current_turn = current_turn;
+    }
+
+    public void upadteIsEnd() {
+        this.isEnd = true;
     }
 
     @Override

--- a/src/main/java/com/study/modoos/study/entity/StudyStatus.java
+++ b/src/main/java/com/study/modoos/study/entity/StudyStatus.java
@@ -1,0 +1,36 @@
+package com.study.modoos.study.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.modoos.common.exception.ErrorCode;
+import com.study.modoos.common.exception.ModoosException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyStatus {
+    RECRUITING("모집 중"),
+    RECRUIT_END("모집 마감"),
+    ONGOING("진행 중"),
+    STUDY_END("종료");
+
+    private static final Map<String, StudyStatus> statusMap = Stream.of(values())
+            .collect(Collectors.toMap(StudyStatus::getStatusName, Function.identity()));
+
+    @JsonValue
+    private final String statusName;
+
+    @JsonCreator
+    public static StudyStatus resolve(String statusName) {
+        return Optional.ofNullable(statusMap.get(statusName))
+                .orElseThrow(() -> new ModoosException(ErrorCode.VALUE_NOT_IN_OPTION));
+    }
+
+}

--- a/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/study/modoos/study/repository/StudyRepositoryImpl.java
@@ -24,8 +24,8 @@ import org.springframework.util.StringUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.study.modoos.study.entity.QStudy.study;
 import static com.study.modoos.participant.entity.QParticipant.participant;
+import static com.study.modoos.study.entity.QStudy.study;
 
 @Repository
 @RequiredArgsConstructor
@@ -56,6 +56,7 @@ public class StudyRepositoryImpl {
                 //.orderBy(study.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1);
+
 
         for (Sort.Order o : pageable.getSort()) {
             PathBuilder pathBuilder = new PathBuilder(study.getType(), study.getMetadata());
@@ -112,7 +113,7 @@ public class StudyRepositoryImpl {
 
     public Slice<RecruitListInfoResponse> getMyStudyList(Member member, Pageable pageable) {
         JPAQuery<Participant> results = queryFactory.selectFrom(participant)
-                .join(participant.study,study)
+                .join(participant.study, study)
                 .where(participant.member.eq(member))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1);


### PR DESCRIPTION
## 작업 내용 :technologist:
- 스터디 출석, 피드백 반영시 아웃처리와 점수 update 로직을 추가했습니다.
- 무한 스크롤 시에 sort 값에 따른 정렬 순서를 지정했습니다.
- 스터디 상태를 StudyStatus enum으로 관리하도록 변경했습니다.

## 반영 브랜치 :rocket:
studyScore/xloyeon -> main

## To Reviewers :speech_balloon:
- 관련 파일은 노션 참고해주세요!
- 
