### PR TITLE
refactor : 메인페이지 무한스크롤 정렬 수정

### DIFF
--- a/src/main/java/com/study/modoos/heart/response/HeartResponse.java
+++ b/src/main/java/com/study/modoos/heart/response/HeartResponse.java
@@ -25,7 +25,7 @@ public class HeartResponse {
     private String leader_nickname;
 
     private String leader_ranking;
-
+    
     private String title;
 
     private String description;

--- a/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
+++ b/src/main/java/com/study/modoos/recruit/controller/RecruitController.java
@@ -11,10 +11,8 @@ import com.study.modoos.recruit.response.RecruitListInfoResponse;
 import com.study.modoos.recruit.service.RecruitService;
 import com.study.modoos.study.entity.StudyStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,20 +43,11 @@ public class RecruitController {
                                                                          @RequestParam(value = "category", defaultValue = "") List<String> category,
                                                                          @RequestParam(value = "searchBy", required = false) String search,
                                                                          @RequestParam(value = "lastId", required = false) Long lastId,
+                                                                         @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
                                                                          @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
 
-        Sort.Direction direction;
 
-        if (pageable.getSort().stream().anyMatch(o -> o.getProperty().equals("recruit_deadLine"))) {
-            direction = Sort.Direction.ASC;
-        } else {
-            direction = DESC;
-        }
-
-        Sort sort = Sort.by(new Sort.Order(direction, pageable.getSort().toString()));
-
-        Pageable pageableWithSort = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, lastId, pageableWithSort));
+        return ResponseEntity.ok(recruitService.getRecruitList(member, search, category, lastId, sortBy, pageable));
 
     }
 

--- a/src/main/java/com/study/modoos/recruit/service/RecruitService.java
+++ b/src/main/java/com/study/modoos/recruit/service/RecruitService.java
@@ -92,14 +92,23 @@ public class RecruitService {
         return RecruitInfoResponse.of(study, false, checkList, participantResponseList);
     }
 
-    public Slice<RecruitListInfoResponse> getRecruitList(Member member, String search, List<String> categoryList, Long lastId, Pageable pageable) {
+    public Slice<RecruitListInfoResponse> getRecruitList(Member member, String search, List<String> categoryList, Long lastId, String sortBy, Pageable pageable) {
 
         List<Category> categories = new ArrayList<>();
 
         for (String s : categoryList) {
             categories.add(Category.resolve(s));
         }
-        return studyRepositoryImpl.getSliceOfRecruit(member, search, categories, lastId, pageable);
+
+        Study lastStudy;
+
+        if (lastId == null) {
+            lastStudy = null;
+        } else {
+            lastStudy = studyRepository.findById(lastId)
+                    .orElse(null);
+        }
+        return studyRepositoryImpl.getSliceOfRecruit(member, search, categories, lastId, lastStudy, sortBy, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/study/modoos/study/entity/Study.java
+++ b/src/main/java/com/study/modoos/study/entity/Study.java
@@ -113,6 +113,7 @@ public class Study extends BaseTimeEntity {
     @OrderBy("id asc")
     private List<Comment> comments;
 
+    @ColumnDefault("false")
     @Column(name = "isEnd")
     private boolean isEnd;
 
@@ -143,6 +144,7 @@ public class Study extends BaseTimeEntity {
         this.late = late;
         this.out = out;
         this.status = StudyStatus.RECRUITING;
+        this.isEnd = false;
     }
 
     public void update(Campus campus, Channel channel, Category category, LocalDate expected_start_at,
@@ -195,7 +197,7 @@ public class Study extends BaseTimeEntity {
     public void upadteIsEnd() {
         this.isEnd = true;
     }
-  
+
     public void addHeart() {
         this.heart++;
     }


### PR DESCRIPTION
## 작업 내용 :technologist:
- pagaable의 sort를 사용하지 않고 직접 파라미터를 추가하여 정렬 방향을 지정하도록 했습니다.

## 반영 브랜치 :rocket:
studyScores/xloyeon -> main

## To Reviewers :speech_balloon:
- 
