### PR TITLE
fix : 스터디 모집 공고 생성 일자 전달

### DIFF
--- a/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
+++ b/src/main/java/com/study/modoos/recruit/response/RecruitInfoResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -67,6 +68,8 @@ public class RecruitInfoResponse {
 
     private boolean isHeart;
 
+    private LocalDateTime createdAt;
+
     public static RecruitInfoResponse of(Study study, boolean isWritten, List<TodoResponse> checkList,
                                          List<StudyParticipantResponse> participantList,
                                          boolean isHeart) {
@@ -95,6 +98,7 @@ public class RecruitInfoResponse {
                 .absent(study.getAbsent())
                 .out(study.getOut())
                 .isHeart(isHeart)
+                .createdAt(study.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
## 작업 내용 :technologist:
- 스터디 모집 공고 상세 조회 시 모집 공고 생성 일자를 전달하도록 수정했습니다.
 
## 반영 브랜치 :rocket:
checkStudyEnd/xloyeon -> main

## To Reviewers :speech_balloon:
- 
